### PR TITLE
feat: noop partitions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -31,6 +31,8 @@ let {
   config.lvm = q: x:
     foldl' recursiveUpdate {} (mapAttrsToList (name: config-f { inherit name; vgname = x.name; }) x.lvs);
 
+  config.noop = q: x: {};
+
   config.partition = q: x:
     config-f { device = q.device + toString q.index; } x.content;
 
@@ -64,6 +66,8 @@ let {
     vgcreate ${x.name} ${q.device}
     ${concatStrings (mapAttrsToList (name: create-f { inherit name; vgname = x.name; }) x.lvs)}
   '';
+
+  create.noop = q: x: "";
 
   create.partition = q: x: ''
     parted -s ${q.device} mkpart ${x.part-type} ${x.fs-type or ""} ${x.start} ${x.end}
@@ -118,6 +122,8 @@ let {
       vgchange -a y
     '';}
   );
+
+  mount.noop = q: x: {};
 
   mount.partition = q: x:
     mount-f { device = q.device + toString q.index; } x.content;

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -56,11 +56,18 @@ import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }: let
                   };
                   home = {
                     type = "lv";
-                    size = "100M";
+                    size = "10M";
                     content = {
                       type = "filesystem";
                       format = "ext4";
                       mountpoint = "/home";
+                    };
+                  };
+                  raw = {
+                    type = "lv";
+                    size = "10M";
+                    content = {
+                      type = "noop";
                     };
                   };
                 };
@@ -92,6 +99,7 @@ in {
       $machine->succeed("echo 'secret' > /tmp/secret.key");
       $machine->succeed("${pkgs.writeScript "create" ((import ../lib).create disko-config)}");
       $machine->succeed("${pkgs.writeScript "mount" ((import ../lib).mount disko-config)}");
+      $machine->succeed("test -b /dev/mapper/pool-raw");
     '';
 
 })


### PR DESCRIPTION
Some deployments just need a raw block device because the app works better when handling those.

Examples: Ceph, Longhorn, OpenEBS.

The new `noop` type supports that. It just does nothing with the partitions created, whenever applied.

@moduon MT-904