### PR TITLE
feat: flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,15 @@ This is how your iso configuation may look like
 ```nix
 { pkgs, ... }:
 let
-  disko = (builtins.fetchGit {
-    url = https://cgit.lassul.us/disko/;
-    rev = "88f56a0b644dd7bfa8438409bea5377adef6aef4";
-  }) + "/lib";
+  disko = import (builtins.fetchGit {
+    url = https://github.com/nix-community/disko;
+    rev = "22b87e5c0a6fc32bb75f91f4465ba9651c2c13ca";
+  }) {};
   cfg = builtins.fromJSON ./tsp-disk.json;
+  create = pkgs.writeScript "tsp-create" (disko.create cfg);
+  mount = pkgs.writeScript "tsp-mount" (disko.mount cfg);
 in {
-  imports = [
-    <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix>
-  ];
-  environment.systemPackages = with pkgs;[
-    (pkgs.writeScriptBin "tsp-create" (disko.create cfg))
-    (pkgs.writeScriptBin "tsp-mount" (disko.mount cfg))
-  ];
+  environment.systemPackages = with pkgs; [create mount];
   ## Optional: Automatically creates a service which runs at startup to perform the partitioning
   #systemd.services.install-to-hd = {
   #  enable = true;
@@ -58,7 +54,7 @@ in {
   #  after = ["getty@tty1.service" ];
   #  serviceConfig = {
   #    Type = "oneshot";
-  #    ExecStart = [ (disko.create cfg) (disk.mount cfg) ];
+  #    ExecStart = [ create mount ];
   #    StandardInput = "null";
   #    StandardOutput = "journal+console";
   #    StandardError = "inherit";

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,7 @@
 {
-  inherit (import ./lib) config create mount;
-}
+  lib ? pkgs.lib,
+  pkgs ? import <nixpkgs> {overlays = [(import ./overlay.nix)];},
+  diskoEnv ? pkgs.diskoEnv,
+  ...
+}:
+import ./lib { inherit lib diskoEnv; }

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,4 @@
 {
-  lib ? pkgs.lib,
   pkgs ? import <nixpkgs> {overlays = [(import ./overlay.nix)];},
-  diskoEnv ? pkgs.diskoEnv,
-  ...
 }:
-import ./lib { inherit lib diskoEnv; }
+pkgs.disko.lib

--- a/diskoEnv.nix
+++ b/diskoEnv.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.symlinkJoin {
+    name = "diskoEnv";
+    paths = with pkgs;[
+      # Device and partition tools
+      cryptsetup
+      lvm2.bin
+      parted
+
+      # Packages that provide a mkfs.* binary
+      btrfs-progs
+      dosfstools
+      e2fsprogs
+      f2fs-tools
+      nilfs-utils
+      util-linux
+      xfsprogs
+    ];
+  }

--- a/diskoEnv.nix
+++ b/diskoEnv.nix
@@ -2,6 +2,8 @@
   pkgs.symlinkJoin {
     name = "diskoEnv";
     paths = with pkgs;[
+      bash
+
       # Device and partition tools
       cryptsetup
       lvm2.bin

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658119717,
+        "narHash": "sha256-4upOZIQQ7Bc4CprqnHsKnqYfw+arJeAuU+QcpjYBXW0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9eb60f25aff0d2218c848dd4574a0ab5e296cabe",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
         };
       in rec {
         lib = import ./. {inherit pkgs;};
+        packages.env = pkgs.disko.env;
         checks.test = import (./. + "/tests/test.nix")
           {inherit nixpkgs; diskoLib = lib;}
           {inherit pkgs system;};

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "nix-powered automatic disk partitioning";
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    {
+      overlays.default = import (./. + "/overlay.nix");
+    }
+    // flake-utils.lib.eachSystem ["x86_64-linux"] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [self.overlays.default];
+        };
+      in rec {
+        lib = import ./. {inherit pkgs;};
+        checks.test = import (./. + "/tests/test.nix")
+          {inherit nixpkgs; diskoLib = lib;}
+          {inherit pkgs system;};
+      }
+    );
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,4 @@
-final: prev: {
-  diskoEnv = import ./diskoEnv.nix {pkgs = final;};
+final: prev: rec {
+  disko.env = import ./diskoEnv.nix {pkgs = final;};
+  disko.lib = import ./lib {diskoEnv = disko.env; lib = final.lib;};
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  diskoEnv = import ./diskoEnv.nix {pkgs = final;};
+}

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -1,4 +1,8 @@
-import <nixpkgs/nixos/tests/make-test-python.nix> ({ pkgs, ... }: let
+{
+  nixpkgs ? <nixpkgs>,
+  diskoLib ? import ../. {},
+}:
+import (nixpkgs + "/nixos/tests/make-test-python.nix") ({ pkgs, ... }: let
 
   disko-config = {
     type = "devices";
@@ -87,8 +91,8 @@ in {
 
     {
       imports = [
-        <nixpkgs/nixos/modules/profiles/installation-device.nix>
-        <nixpkgs/nixos/modules/profiles/base.nix>
+        (nixpkgs + "/nixos/modules/profiles/installation-device.nix")
+        (nixpkgs + "/nixos/modules/profiles/base.nix")
       ];
 
       virtualisation.emptyDiskImages = [ 512 ];
@@ -97,8 +101,8 @@ in {
   testScript =
     ''
       machine.succeed("echo 'secret' > /tmp/secret.key");
-      machine.succeed("${pkgs.writeScript "create" ((import ../lib).create disko-config)}");
-      machine.succeed("${pkgs.writeScript "mount" ((import ../lib).mount disko-config)}");
+      machine.succeed("${pkgs.writeScript "create" (diskoLib.create disko-config)}");
+      machine.succeed("${pkgs.writeScript "mount" (diskoLib.mount disko-config)}");
       machine.succeed("test -b /dev/mapper/pool-raw");
     '';
 


### PR DESCRIPTION
Without this, the module cannot be used with flakes, because it fails with `cannot look up '<nixpkgs/lib>' in pure evaluation mode (use '--impure' to override)`.

@moduon MT-904