### PR TITLE
[WIP] Implement by-id disk device partition handling

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -35,7 +35,7 @@ let {
   config.noop = q: x: {};
 
   config.partition = q: x:
-    config-f { device = q.device + toString q.index; } x.content;
+    config-f { device = q.device + "-part" + toString q.index; } x.content;
 
   config.table = q: x:
     foldl' recursiveUpdate {} (imap (index: config-f (q // { inherit index; })) x.partitions);
@@ -78,7 +78,7 @@ let {
     ${concatMapStringsSep "" (flag: ''
       parted -s ${q.device} set ${toString q.index} ${flag} on
     '') (x.flags or [])}
-    ${create-f { device = q.device + toString q.index; } x.content}
+    ${create-f { device = q.device + "-part" + toString q.index; } x.content}
   '';
 
   create.table = q: x: ''
@@ -129,7 +129,7 @@ let {
   mount.noop = q: x: {};
 
   mount.partition = q: x:
-    mount-f { device = q.device + toString q.index; } x.content;
+    mount-f { device = q.device + "-part" + toString q.index; } x.content;
 
   mount.table = q: x:
     foldl' recursiveUpdate {} (imap (index: mount-f (q // { inherit index; })) x.partitions);


### PR DESCRIPTION
Currently adding a device by id messes with the functionality of the script, as it tries appending the partition index to the name when the format for by-id disks is $NAME-part$INDEX instead of the assumed $NAME$index.

This implementation is in progress as we need a way to determine if the user has chosen the traditional or the by-id way to identify a disk in order to handle the partition names correctly.

imho I think we should promote/make-default the use of the by-id way of identifying disks as it provides a more declarative and deterministic way of identifying disks.