### PR TITLE
fix(btrfs): subvolume options support in mount and config

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -84,7 +84,7 @@ let
     let
       subvolumeNames = attrNames x.subvolumes;
     in ''
-    mkfs.btrfs ${q.device}
+    mkfs.btrfs ${q.device} ${x.extraArgs or ""}
     ${lib.optionalString (!isNull x.subvolumes or null) ''
       MNTPOINT=$(mktemp -d)
       (

--- a/default.nix
+++ b/default.nix
@@ -84,6 +84,7 @@ let
     let
       subvolumeNames = attrNames x.subvolumes;
     in ''
+    udevadm trigger --subsystem-match=block; udevadm settle
     mkfs.btrfs ${q.device} ${x.extraArgs or ""}
     ${lib.optionalString (!isNull x.subvolumes or null) ''
       MNTPOINT=$(mktemp -d)
@@ -96,6 +97,7 @@ let
   '';
 
   create.filesystem = q: x: ''
+    udevadm trigger --subsystem-match=block; udevadm settle
     mkfs.${x.format} \
       ${lib.optionalString (!isNull x.extraArgs or null) x.extraArgs} \
       ${q.device}

--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -12,6 +12,7 @@
           end = "100%";
           content = {
             type = "btrfs";
+            extraArgs = "-f"; # Override existing partition
             subvolumes = {
               # Subvolume name is different from mountpoint
               rootfs = {

--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -12,15 +12,23 @@
           end = "100%";
           content = {
             type = "btrfs";
-            mountpoint = "/";
-            subvolumes = [
-              "/home"
-              "/test"
-            ];
+            subvolumes = {
+              # Subvolume name is different from mountpoint
+              rootfs = {
+                mountpoint = "/";
+              };
+              # Mountpoint s inferred from subvolume name
+              "/home" = {
+                mountOptions = ["compress=zstd"];
+              };
+              "/nix" = {
+                mountOptions = ["compress=zstd" "noatime"];
+              };
+              "/test" = {};
+            };
           };
         }
       ];
     };
   };
 }
-


### PR DESCRIPTION
- Add `config.btrfs`.
- Fix `mount.filesystem` when extra `mountOptions` were used (they were split by space instead of comma).
- Support btrfs subvolumes and mount options in `mount.btrfs`.
- Support the case where a subvolume is named different than its mountpoint.

BREAKING CHANGE: This changes the btrfs layout for subvolumes from a list of strings to a set. This is needed to let the set include other options.

@moduon MT-1075