### PR TITLE
fix: mkfs randomly not detecting just partitioned device

### DIFF
--- a/types.nix
+++ b/types.nix
@@ -464,6 +464,8 @@ rec {
           ${concatMapStringsSep "" (flag: ''
             parted -s ${dev} set ${toString config.index} ${flag} on
           '') config.flags}
+          # ensure further operations can detect new partitions
+          udevadm trigger --subsystem-match=block; udevadm settle
           ${optionalString (!isNull config.content) (config.content._create (diskoLib.deviceNumbering dev config.index))}
         '';
       };


### PR DESCRIPTION
@moduon MT-1248