### PR TITLE
add support for mmc blk devices

### DIFF
--- a/types.nix
+++ b/types.nix
@@ -63,6 +63,7 @@ rec {
           if match "/dev/disk/.*" dev != null then "dev_disk" else
           if match "/dev/nvme.*" dev != null then "dev_nvme" else
           if match "/dev/md/.*" dev != null then "dev_md" else
+          if match "/dev/mmcblk.*" dev != null then "dev_nvme" else
           abort "${dev} seems not to be a supported disk format";
       in schemas.${detectSchema};
 


### PR DESCRIPTION
eMMC and SD cards will show up as `/dev/mmcblk0` on most machines and they follow the same partitioning scheme as nvme devices (e.g `/dev/mmcblk0p1`)