### PR TITLE
Allow shell variables in disks parameter 

### DIFF
--- a/types.nix
+++ b/types.nix
@@ -1327,7 +1327,9 @@ rec {
         internal = true;
         readOnly = true;
         default =
-          optional (!isNull config.content) (config.content._config config.device);
+          if optionTypes.shell-variable.check config.device
+          then throw "NixOS config can't be generated when using shell variables."
+          else optional (!isNull config.content) (config.content._config config.device);
       };
       _pkgs = mkOption {
         internal = true;


### PR DESCRIPTION
...which are expanded at run-time.

While this limits the declarative nature of disko a bit, i believe its useful as it allows pre-generating the scripts for systems which don't run nix (yet) while still keeping the flexibility of declaring disks to use at-runtime.

Generate the script: 
```
disko-create-zfs = self.lib.createScriptNoDeps (import ./example/zfs.nix { disks = ["\${disk1}" "\${disk2}" ]; }) pkgs;
```
(one could use positional parameters like `${1}` if preferred)

Call it at runtime:

```
disk1=/dev/vda disk2=/dev/vdb bash disko-create-zfs-simple
```

This seems to work for me and was easy to implement. What do you think?