### PR TITLE
enable nix run

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -20,23 +20,23 @@ in {
     };
   };
   config = lib.mkIf (cfg.devices.disk != {}) {
-    system.build.formatScript = pkgs.writers.writeBash "disko-create" ''
+    system.build.formatScript = pkgs.writers.writeBashBin "disko-create" ''
       export PATH=${lib.makeBinPath (types.diskoLib.packages cfg.devices pkgs)}:$PATH
       ${types.diskoLib.create cfg.devices}
     '';
 
-    system.build.mountScript = pkgs.writers.writeBash "disko-mount" ''
+    system.build.mountScript = pkgs.writers.writeBashBin "disko-mount" ''
       export PATH=${lib.makeBinPath (types.diskoLib.packages cfg.devices pkgs)}:$PATH
       ${types.diskoLib.mount cfg.devices}
     '';
 
-    system.build.disko = pkgs.writers.writeBash "disko" ''
+    system.build.disko = pkgs.writers.writeBashBin "disko" ''
       export PATH=${lib.makeBinPath (types.diskoLib.packages cfg.devices pkgs)}:$PATH
       ${types.diskoLib.zapCreateMount cfg.devices}
     '';
 
     # This is useful to skip copying executables uploading a script to an in-memory installer
-    system.build.diskoNoDeps = pkgs.writeScript "disko" ''
+    system.build.diskoNoDeps = pkgs.writeScriptBin "disko" ''
       #!/usr/bin/env bash
       ${types.diskoLib.zapCreateMount cfg.devices}
     '';

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -132,10 +132,10 @@
           machine.succeed("${tsp-disko}") # verify that we can destroy and recreate
         ''}
         ${lib.optionalString (testMode == "module") ''
-          machine.succeed("${nodes.machine.system.build.formatScript}")
-          machine.succeed("${nodes.machine.system.build.mountScript}")
-          machine.succeed("${nodes.machine.system.build.mountScript}") # verify that the command is idempotent
-          machine.succeed("${nodes.machine.system.build.disko}") # verify that we can destroy and recreate again
+          machine.succeed("${nodes.machine.system.build.formatScript}/bin/disko-create")
+          machine.succeed("${nodes.machine.system.build.mountScript}/bin/disko-mount")
+          machine.succeed("${nodes.machine.system.build.mountScript}/bin/disko-mount") # verify that the command is idempotent
+          machine.succeed("${nodes.machine.system.build.disko}/bin/disko") # verify that we can destroy and recreate again
         ''}
         ${lib.optionalString (testMode == "cli") ''
           # TODO use the disko cli here


### PR DESCRIPTION
Is there a reason why something like this is not done so that `nix run .#nixosConfigurations.myhostname.config.system.build.diskoNoDeps` could setup disks prior to `nixos-install --flake .#myhostname`? This saves running build and then the result script.

Great work. Thanks for your effort.