### PR TITLE
Add lvm2 package to use `blkdeactivate`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ in {
   create = cfg: types.diskoLib.create (eval cfg).config.devices;
   createScript = cfg: pkgs: pkgs.writeScript "disko-create" ''
     #!/usr/bin/env bash
-    export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}
+    export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}:$PATH
     ${types.diskoLib.create (eval cfg).config.devices}
   '';
   createScriptNoDeps = cfg: pkgs: pkgs.writeScript "disko-create" ''
@@ -27,7 +27,7 @@ in {
   mount = cfg: types.diskoLib.mount (eval cfg).config.devices;
   mountScript = cfg: pkgs: pkgs.writeScript "disko-mount" ''
     #!/usr/bin/env bash
-    export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}
+    export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}:$PATH
     ${types.diskoLib.mount (eval cfg).config.devices}
   '';
   mountScriptNoDeps = cfg: pkgs: pkgs.writeScript "disko-mount" ''
@@ -37,7 +37,7 @@ in {
   zapCreateMount = cfg: types.diskoLib.zapCreateMount (eval cfg).config.devices;
   zapCreateMountScript = cfg: pkgs: pkgs.writeScript "disko-zap-create-mount" ''
     #!/usr/bin/env bash
-    export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}
+    export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}:$PATH
     ${types.diskoLib.zapCreateMount (eval cfg).config.devices}
   '';
   zapCreateMountScriptNoDeps = cfg: pkgs: pkgs.writeScript "disko-zap-create-mount" ''

--- a/types.nix
+++ b/types.nix
@@ -605,8 +605,9 @@ rec {
         internal = true;
         readOnly = true;
         type = types.functionTo (types.listOf types.package);
+        # lvm2 package is required hereafter to use `blkdeactivate` in `zapCreateMount` script
         default = pkgs:
-          [ pkgs.parted pkgs.systemdMinimal ] ++ flatten (map (partition: partition._pkgs pkgs) config.partitions);
+          [ pkgs.parted pkgs.systemdMinimal pkgs.lvm2 pkgs.gnugrep pkgs.coreutils pkgs.findutils ] ++ flatten (map (partition: partition._pkgs pkgs) config.partitions);
       };
     };
   });


### PR DESCRIPTION
Zap script uses `blkdeactivate` to deactivates block devices. `blkdeactivate` is currently in the lvm2 package.
Add grep/find/cut tools as well as we are fixing complete PATH.