### PR TITLE
types: add btrfs_subvol type

### DIFF
--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -27,11 +27,21 @@
             end = "100%";
             content = {
               type = "btrfs";
-              mountpoint = "/";
-              subvolumes = [
-                "/home"
-                "/test"
-              ];
+              extraArgs = "-f"; # Override existing partition
+              subvolumes = {
+                # Subvolume name is different from mountpoint
+                "/rootfs" = {
+                  mountpoint = "/";
+                };
+                # Mountpoints inferred from subvolume name
+                "/home" = {
+                  mountOptions = ["compress=zstd"];
+                };
+                "/nix" = {
+                  mountOptions = ["compress=zstd" "noatime"];
+                };
+                "/test" = {};
+              };
             };
           }
         ];


### PR DESCRIPTION
This adds support for specifying separate configuration and mount points for BTRFS subvolumes by implementing them as a new subtype for the `btrfs` type

It sort of follows from the work in #33, but does not use any of that implementation because disko has largely been rewritten since then to use types

I believe I've done everything mostly reasonably (since I copied the patterns LVM and ZFS were using for the most part), but I don't actually fully know what I'm doing, so please let me know if some things should be done differently

I've tested this by installing my new laptop from my config (see the disko config [here](https://github.com/lilyinstarlight/foosteros/blob/e52af84684ca462ccc8f8e57a5cdd5c3a818407b/hosts/bina/hardware-configuration.nix#L62-L134)) and via the flake checks in disko

Also of note: With the way this works, it does not create separate mountpoints if the parent btrfs filesystem has a mountpoint specified and the subvolume does not have one specified (it only gets created via `btrfs subvolume create`). That means this PR follows previous behavior when changing:

```
{
  type = "btrfs";
  mountpoint = "/";
  subvolumes = [
    "/home"
    "/nix"
    "/test"
  ];
}
```

to:

```
{
  type = "btrfs";
  mountpoint = "/";
  subvolumes = {
    "/home" = {};
    "/nix" = {};
    "/test" = {};
  };
}
```

even though changing the type is a breaking change.