### PR TITLE
swap: fix typo for checking if swap is on

### DIFF
--- a/types.nix
+++ b/types.nix
@@ -655,7 +655,7 @@ rec {
         type = types.functionTo diskoLib.jsonType;
         default = dev: {
           fs.${dev} = ''
-            if ! $(swapon --show | grep -q '^${dev} '); then
+            if ! swapon --show | grep -q '^${dev} '; then
               swapon ${dev}
             fi
           '';


### PR DESCRIPTION
Simple little error shellcheck happened to find. If you're trying to get the exit status of `grep` in that command pipe, I believe a command group is intended, not command substitution