### PR TITLE
types: pass through mountOptions to _config for all types

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -109,7 +109,7 @@
             type = "filesystem";
             format = "ext4";
             mountpoint = "/ext4_on_lvm";
-            options = [
+            mountOptions = [
               "defaults"
             ];
           };

--- a/example/luks-lvm.nix
+++ b/example/luks-lvm.nix
@@ -17,7 +17,7 @@
               type = "filesystem";
               format = "vfat";
               mountpoint = "/boot";
-              options = [
+              mountOptions = [
                 "defaults"
               ];
             };
@@ -52,7 +52,7 @@
             type = "filesystem";
             format = "ext4";
             mountpoint = "/";
-            options = [
+            mountOptions = [
               "defaults"
             ];
           };

--- a/example/lvm-raid.nix
+++ b/example/lvm-raid.nix
@@ -89,7 +89,7 @@
             type = "filesystem";
             format = "ext4";
             mountpoint = "/";
-            options = [
+            mountOptions = [
               "defaults"
             ];
           };

--- a/example/zfs-over-legacy.nix
+++ b/example/zfs-over-legacy.nix
@@ -17,7 +17,7 @@
               type = "filesystem";
               format = "vfat";
               mountpoint = "/boot";
-              options = [
+              mountOptions = [
                 "defaults"
               ];
             };

--- a/types.nix
+++ b/types.nix
@@ -266,7 +266,7 @@ rec {
       };
       mountOptions = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ "defaults" ];
       };
       _meta = mkOption {
         internal = true;
@@ -323,7 +323,7 @@ rec {
       };
       mountOptions = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ "defaults" ];
       };
       subvolumes = mkOption {
         type = types.listOf optionTypes.pathname;
@@ -376,6 +376,7 @@ rec {
           fileSystems.${config.mountpoint} = {
             device = dev;
             fsType = "btrfs";
+            options = config.mountOptions;
           };
         }];
       };
@@ -400,11 +401,7 @@ rec {
       };
       mountOptions = mkOption {
         type = types.listOf types.str;
-        default = [];
-      };
-      options = mkOption {
-        type = types.listOf types.str;
-        default = [];
+        default = [ "defaults" ];
       };
       mountpoint = mkOption {
         type = optionTypes.absolute-pathname;
@@ -450,6 +447,7 @@ rec {
           fileSystems.${config.mountpoint} = {
             device = dev;
             fsType = config.format;
+            options = config.mountOptions;
           };
         }];
       };
@@ -932,7 +930,7 @@ rec {
       };
       mountOptions = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ "defaults" ];
       };
       datasets = mkOption {
         type = types.attrsOf zfs_dataset;
@@ -990,7 +988,7 @@ rec {
             fileSystems.${config.mountpoint} = {
               device = config.name;
               fsType = "zfs";
-              options = lib.optional ((config.options.mountpoint or "") != "legacy") "zfsutil";
+              options = config.mountOptions ++ lib.optional ((config.options.mountpoint or "") != "legacy") "zfsutil";
             };
           })
         ];
@@ -1024,7 +1022,7 @@ rec {
       };
       mountOptions = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ "defaults" ];
       };
 
       # filesystem options
@@ -1086,7 +1084,7 @@ rec {
             fileSystems.${config.mountpoint} = {
               device = "${zpool}/${config.name}";
               fsType = "zfs";
-              options = lib.optional ((config.options.mountpoint or "") != "legacy") "zfsutil";
+              options = config.mountOptions ++ lib.optional ((config.options.mountpoint or "") != "legacy") "zfsutil";
             };
           });
       };


### PR DESCRIPTION
So the `filesystem.options` option never seemed to actually be used anywhere in disko (for creating, mounting, or configuring) and it seems to have been confused with the `mountOptions` option, which is used but often only during `_mount` and not `_config` (except for `nodev` where it was passed through correctly)

I may be off-base with that observation (still trying to fully figure disko out tbh) but if that observation is correct, this PR removes the `filesystems.options` type and passes through `filesystems.mountOptions` through to the filesystem definitions output by `_config` so that they get propagated to the system config as well

I also had to update the tests which used `filesystem.options` (which did not seem to do anything) in the place of using `filesystem.mountOptions` to specify mount options

I ran the tests to confirm this worked (and I had btrfs pass them through in #82 like this PR has), but let me know if anything in this change seems problematic or if I'm not understanding things correctly