### PR TITLE
pre/post create hooks

### DIFF
--- a/example/config.nix
+++ b/example/config.nix
@@ -5,7 +5,7 @@
       type = "lvm_vg";
       lvs = {
         root = {
-          type = "lv";
+          type = "lvm_lv";
           size = "10G";
           content = {
             type = "filesystem";
@@ -14,7 +14,7 @@
           };
         };
         home = {
-          type = "lv";
+          type = "lvm_lv";
           size = "10G";
           content = {
             type = "filesystem";
@@ -33,9 +33,8 @@
         format = "gpt";
         partitions = [
           {
-            name = "boot";
+            name = "ESP";
             type = "partition";
-            part-type = "ESP";
             start = "1MiB";
             end = "1024MiB";
             fs-type = "fat32";

--- a/example/stand-alone/configuration.nix
+++ b/example/stand-alone/configuration.nix
@@ -18,7 +18,7 @@
     disk = {
       sda = {
         device = "/dev/sda";
-        type = "device";
+        type = "disk";
         content = {
           type = "table";
           format = "msdos";

--- a/module.nix
+++ b/module.nix
@@ -20,12 +20,12 @@ in {
     };
   };
   config = lib.mkIf (cfg.devices.disk != {}) {
-    system.build.formatScript = pkgs.writers.writeDash "disko-create" ''
+    system.build.formatScript = pkgs.writers.writeBash "disko-create" ''
       export PATH=${lib.makeBinPath (types.diskoLib.packages cfg.devices pkgs)}:$PATH
       ${types.diskoLib.create cfg.devices}
     '';
 
-    system.build.mountScript = pkgs.writers.writeDash "disko-mount" ''
+    system.build.mountScript = pkgs.writers.writeBash "disko-mount" ''
       export PATH=${lib.makeBinPath (types.diskoLib.packages cfg.devices pkgs)}:$PATH
       ${types.diskoLib.mount cfg.devices}
     '';

--- a/types.nix
+++ b/types.nix
@@ -1159,7 +1159,9 @@ rec {
             ${concatStringsSep " " (mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
             ${concatStringsSep " " (mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
             ''${ZFSDEVICES_${config.name}}
-          zfs set ${concatStringsSep " " (mapAttrsToList (n: v: "${n}=${v}") config.optionsAfterCreate)} ${config.name}
+          ${lib.optionalString
+            (config.optionsAfterCreate != {})
+            "zfs set ${concatStringsSep " " (mapAttrsToList (n: v: "${n}=${v}") config.optionsAfterCreate)} ${config.name}"}
           ${concatMapStrings (dataset: dataset._create config.name) (attrValues config.datasets)}
         '';
         description = "Creation script";

--- a/types.nix
+++ b/types.nix
@@ -1118,6 +1118,10 @@ rec {
         default = {};
         description = "Options for the ZFS pool";
       };
+      optionsAfterCreate = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+      };
       rootFsOptions = mkOption {
         type = types.attrsOf types.str;
         default = {};
@@ -1155,6 +1159,7 @@ rec {
             ${concatStringsSep " " (mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
             ${concatStringsSep " " (mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
             ''${ZFSDEVICES_${config.name}}
+          zfs set ${concatStringsSep " " (mapAttrsToList (n: v: "${n}=${v}") config.optionsAfterCreate)} ${config.name}
           ${concatMapStrings (dataset: dataset._create config.name) (attrValues config.datasets)}
         '';
         description = "Creation script";

--- a/types.nix
+++ b/types.nix
@@ -137,15 +137,16 @@ rec {
 
     hookMixin = { config, options,... }: {
       options = let
-        mkHook = mkOption {
+        mkHook = description: mkOption {
+          inherit description;
           type = types.str;
           default = "";
         };
       in {
-        preCreateHook = mkHook;
-        postCreateHook = mkHook;
-        preMountHook = mkHook;
-        postMountHook = mkHook;
+        preCreateHook = mkHook "shell commands to run before create";
+        postCreateHook = mkHook "shell commands to run after create";
+        preMountHook = mkHook "shell commands to run before mount";
+        postMountHook = mkHook "shell commands to run after mount";
       };
     };
 

--- a/types.nix
+++ b/types.nix
@@ -159,12 +159,12 @@ rec {
               test = lib.optionalString (config ? name) "${config.${name}}";
           in
           ''
-          ( # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
+          { # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
             ${diskoLib.defineHookVariables { inherit config options; }}
             ${config.preCreateHook}
             ${attrs.default args}
             ${config.postCreateHook}
-          )
+          }
           '';
         description = "Creation script";
       };

--- a/types.nix
+++ b/types.nix
@@ -141,24 +141,6 @@ rec {
       };
     };
 
-    mkCreateOption = { config, options, default }:
-      mkOption {
-        description = "Creation script";
-        internal = true;
-        readOnly = true;
-        type = types.str;
-        default = lib.concatStringsSep "\n" [
-          "(" #subshell for namespacing
-          (diskoLib.defineHookVariables { inherit config options; })
-          config.preCreateHook
-          default
-          config.postCreateHook
-          ")"
-        ];
-      };
-
-
-
     /* Takes a disko device specification, returns an attrset with metadata
 
        meta :: types.devices -> AttrSet
@@ -1189,8 +1171,10 @@ rec {
           diskoLib.deepMergeMap (dataset: dataset._meta [ "zpool" config.name ]) (attrValues config.datasets);
         description = "Metadata";
       };
-      _create = diskoLib.mkCreateOption {
-        inherit config options;
+      _create = mkOption {
+        internal = true;
+        readOnly = true;
+        type = types.str;
         default = ''
           zpool create ${config.name} \
             ${config.mode} \
@@ -1199,6 +1183,7 @@ rec {
             ''${ZFSDEVICES_${config.name}}
           ${concatMapStrings (dataset: dataset._create config.name) (attrValues config.datasets)}
         '';
+        description = "Creation script";
       };
       _mount = mkOption {
         internal = true;

--- a/types.nix
+++ b/types.nix
@@ -174,7 +174,7 @@ rec {
         internal = true;
         readOnly = true;
         type = types.functionTo diskoLib.jsonType;
-        default = args: let v = attrs.default args; in lib.traceSeqN 3 [(config.name or "unnamed") (v.fs or "")] v;
+        default = args: attrs.default args;
         description = "Mount script";
       };
 

--- a/types.nix
+++ b/types.nix
@@ -159,12 +159,12 @@ rec {
               test = lib.optionalString (config ? name) "${config.${name}}";
           in
           ''
-          { # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
+          ( # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
             ${diskoLib.defineHookVariables { inherit config options; }}
             ${config.preCreateHook}
             ${attrs.default args}
             ${config.postCreateHook}
-          }
+          )
           '';
         description = "Creation script";
       };

--- a/types.nix
+++ b/types.nix
@@ -159,12 +159,12 @@ rec {
               test = lib.optionalString (config ? name) "${config.${name}}";
           in
           ''
-          ( # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
+          function { # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
             ${diskoLib.defineHookVariables { inherit config options; }}
             ${config.preCreateHook}
             ${attrs.default args}
             ${config.postCreateHook}
-          )
+          }
           '';
         description = "Creation script";
       };

--- a/types.nix
+++ b/types.nix
@@ -155,11 +155,13 @@ rec {
         readOnly = true;
         type = types.functionTo types.str;
         default = args:
-          lib.concatStrings [
+          lib.concatStringsSep "\n" [
+            "(" # subshell for namespacing
             (diskoLib.defineHookVariables { inherit config options; })
             config.preCreateHook
             (default args)
             config.postCreateHook
+            ")"
           ];
         description = "Creation script";
       };

--- a/types.nix
+++ b/types.nix
@@ -137,15 +137,15 @@ rec {
 
     hookMixin = { config, options,... }: {
       options = let
-        mkHook = default: mkOption {
+        mkHook = mkOption {
           type = types.str;
-          default = default;
+          default = "";
         };
       in {
-        preCreateHook = mkHook "echo 'DEBUG preCreate: ${config.type}'";
-        postCreateHook = mkHook "echo 'DEBUG postCreate: ${config.type}'";
-        preMountHook = mkHook "echo 'DEBUG preMount: ${config.type}'";
-        postMountHook = mkHook "echo 'DEBUG postMount: ${config.type}'";
+        preCreateHook = mkHook;
+        postCreateHook = mkHook;
+        preMountHook = mkHook;
+        postMountHook = mkHook;
       };
     };
 

--- a/types.nix
+++ b/types.nix
@@ -205,7 +205,7 @@ rec {
     in ''
       set -efux
       # first create the necessary devices
-      ${concatMapStrings (dev: ((attrByPath (dev ++ [ "_mount" ]) "" devices) {}).dev ) sortedDeviceList}
+      ${concatMapStrings (dev: ((attrByPath (dev ++ [ "_mount" ]) "" devices) {}).dev or "") sortedDeviceList}
 
       # and then mount the filesystems in alphabetical order
       ${concatStrings (attrValues fsMounts)}

--- a/types.nix
+++ b/types.nix
@@ -141,7 +141,7 @@ rec {
       sortedDeviceList = diskoLib.sortDevicesByDependencies ((diskoLib.meta devices).deviceDependencies or {}) devices;
     in ''
       set -efux
-      ${concatStrings (map (dev: attrByPath (dev ++ [ "_create" ]) "" devices) sortedDeviceList)}
+      ${concatMapStrings (dev: attrByPath (dev ++ [ "_create" ]) "" devices) sortedDeviceList}
     '';
     /* Takes a disko device specification and returns a string which mounts the disks
 
@@ -153,7 +153,7 @@ rec {
     in ''
       set -efux
       # first create the necessary devices
-      ${concatStrings (map (dev: attrByPath (dev ++ [ "_mount" "dev" ]) "" devices) sortedDeviceList)}
+      ${concatMapStrings (dev: attrByPath (dev ++ [ "_mount" "dev" ]) "" devices) sortedDeviceList}
 
       # and then mount the filesystems in alphabetical order
       # attrValues returns values sorted by name.  This is important, because it
@@ -657,7 +657,7 @@ rec {
             partMounts = diskoLib.deepMergeMap (partition: partition._mount dev) config.partitions;
           in {
             dev = ''
-              ${concatStrings (map (x: x.dev or "") (attrValues partMounts))}
+              ${concatMapStrings (x: x.dev or "") (attrValues partMounts)}
             '';
             fs = partMounts.fs or {};
         };
@@ -948,7 +948,7 @@ rec {
         in {
           dev = ''
             vgchange -a y
-            ${concatStrings (map (x: x.dev or "") (attrValues lvMounts))}
+            ${concatMapStrings (x: x.dev or "") (attrValues lvMounts)}
           '';
           fs = lvMounts.fs;
         };
@@ -1186,7 +1186,7 @@ rec {
         in {
           dev = ''
             zpool list '${config.name}' >/dev/null 2>/dev/null || zpool import '${config.name}'
-            ${concatStrings (map (x: x.dev or "") (attrValues datasetMounts))}
+            ${concatMapStrings (x: x.dev or "") (attrValues datasetMounts)}
           '';
           fs = datasetMounts.fs // optionalAttrs (!isNull config.mountpoint) {
             ${config.mountpoint} = ''

--- a/types.nix
+++ b/types.nix
@@ -159,12 +159,12 @@ rec {
               test = lib.optionalString (config ? name) "${config.${name}}";
           in
           ''
-          function { # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
+          ( # ${config.type} ${concatMapStringsSep " " (n: toString (config.${n} or "")) ["name" "device" "format" "mountpoint"]}
             ${diskoLib.defineHookVariables { inherit config options; }}
             ${config.preCreateHook}
             ${attrs.default args}
             ${config.postCreateHook}
-          }
+          )
           '';
         description = "Creation script";
       };


### PR DESCRIPTION
Not sure about the best implementation here yet.

I'd like to use disk encryption with ZFS and existing disko facilities work fine to set it up, but we obviously can't use keylocation=prompt during disko formatting. So unlocking fails on boot if the file referred to by keylocation isn't included in the initrd.

Ideally I could use keylocation=file://tmp/disk.key during partitioning, but set keylocation=prompt right after that.

What do you think? Maybe a generic option to add post-creation shell commands would be a more flexible solution?

example usage:
```
    rpool = {
      type = "zpool";
      mode = "";
      options = {
        ashift = "12";
        autotrim = "on";
      };
      optionsAfterCreate = {
        keylocation = "prompt";
      };
      rootFsOptions = {
        encryption = "on";
        keylocation = "file:///tmp/disk.key";
        keyformat = "passphrase";
        compression = "zstd";
        acltype = "posixacl";
        mountpoint = "none";
        canmount = "off";
        xattr = "sa";
        dnodesize = "auto";
        normalization = "formD";
        relatime = "on";
      };
```