### PR TITLE
Add disks with bootable partition to boot.grub.devices

### DIFF
--- a/tests/gpt-bios-compat.nix
+++ b/tests/gpt-bios-compat.nix
@@ -7,5 +7,4 @@ makeDiskoTest {
     machine.succeed("mountpoint /");
   '';
   efi = false;
-  grub-devices = [ "/dev/vdb" ];
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -9,7 +9,6 @@
     , extraTestScript ? ""
     , bootCommands ? ""
     , extraConfig ? { }
-    , grub-devices ? [ "nodev" ]
     , efi ? true
     , enableOCR ? false
     , postDisko ? ""
@@ -58,7 +57,6 @@
 
         boot.consoleLogLevel = lib.mkForce 100;
         boot.loader.grub = {
-          devices = grub-devices;
           efiSupport = efi;
           efiInstallAsRemovable = efi;
         };

--- a/tests/mdadm.nix
+++ b/tests/mdadm.nix
@@ -8,5 +8,4 @@ makeDiskoTest {
     machine.succeed("mountpoint /");
   '';
   efi = false;
-  grub-devices = [ "/dev/vdb" "/dev/vdc" ];
 }

--- a/tests/with-lib.nix
+++ b/tests/with-lib.nix
@@ -7,5 +7,4 @@ makeDiskoTest {
     machine.succeed("mountpoint /");
   '';
   efi = false;
-  grub-devices = [ "/dev/vdb" ];
 }

--- a/types.nix
+++ b/types.nix
@@ -598,7 +598,8 @@ rec {
         internal = true;
         readOnly = true;
         default = dev:
-          map (partition: partition._config dev) config.partitions;
+          (flatten (map (partition: optional (builtins.elem "bios_grub" partition.flags) { boot.loader.grub.devices = [dev]; }) config.partitions))
+          ++ map (partition: partition._config dev) config.partitions;
       };
       _pkgs = mkOption {
         internal = true;


### PR DESCRIPTION
We could also set it to "nodev" if we have an ESP partition but no bios_grub partition, but i am yet unsure whether that's a robust enough heuristic?