### PR TITLE
types,module,tests: run shellcheck on scripts before running them in NixOS tests

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,3 @@
+2023-02-14 6d630b8
+
+btrfs, btrfs_subvol filesystem and lvm_lv extraArgs are now lists

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { lib ? import <nixpkgs/lib>
 , rootMountPoint ? "/mnt"
+, checked ? false
 }:
 let
   types = import ./types { inherit lib rootMountPoint; };
@@ -18,33 +19,27 @@ in
 {
   types = types;
   create = cfg: types.diskoLib.create (eval cfg).config.devices;
-  createScript = cfg: pkgs: pkgs.writeScript "disko-create" ''
-    #!/usr/bin/env bash
+  createScript = cfg: pkgs: (types.diskoLib.writeCheckedBash { inherit pkgs checked; }) "disko-create" ''
     export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}:$PATH
     ${types.diskoLib.create (eval cfg).config.devices}
   '';
-  createScriptNoDeps = cfg: pkgs: pkgs.writeScript "disko-create" ''
-    #!/usr/bin/env bash
+  createScriptNoDeps = cfg: pkgs: (types.diskoLib.writeCheckedBash { inherit pkgs checked; noDeps = true; }) "disko-create" ''
     ${types.diskoLib.create (eval cfg).config.devices}
   '';
   mount = cfg: types.diskoLib.mount (eval cfg).config.devices;
-  mountScript = cfg: pkgs: pkgs.writeScript "disko-mount" ''
-    #!/usr/bin/env bash
+  mountScript = cfg: pkgs: (types.diskoLib.writeCheckedBash { inherit pkgs checked; }) "disko-mount" ''
     export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}:$PATH
     ${types.diskoLib.mount (eval cfg).config.devices}
   '';
-  mountScriptNoDeps = cfg: pkgs: pkgs.writeScript "disko-mount" ''
-    #!/usr/bin/env bash
+  mountScriptNoDeps = cfg: pkgs: (types.diskoLib.writeCheckedBash { inherit pkgs checked; noDeps = true; }) "disko-mount" ''
     ${types.diskoLib.mount (eval cfg).config.devices}
   '';
   zapCreateMount = cfg: types.diskoLib.zapCreateMount (eval cfg).config.devices;
-  zapCreateMountScript = cfg: pkgs: pkgs.writeScript "disko-zap-create-mount" ''
-    #!/usr/bin/env bash
+  zapCreateMountScript = cfg: pkgs: (types.diskoLib.writeCheckedBash { inherit pkgs checked; }) "disko-zap-create-mount" ''
     export PATH=${lib.makeBinPath (types.diskoLib.packages (eval cfg).config.devices pkgs)}:$PATH
     ${types.diskoLib.zapCreateMount (eval cfg).config.devices}
   '';
-  zapCreateMountScriptNoDeps = cfg: pkgs: pkgs.writeScript "disko-zap-create-mount" ''
-    #!/usr/bin/env bash
+  zapCreateMountScriptNoDeps = cfg: pkgs: (types.diskoLib.writeCheckedBash { inherit pkgs checked; noDeps = true; }) "disko-zap-create-mount" ''
     ${types.diskoLib.zapCreateMount (eval cfg).config.devices}
   '';
   config = cfg: { imports = types.diskoLib.config (eval cfg).config.devices; };

--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -27,7 +27,7 @@
             end = "100%";
             content = {
               type = "btrfs";
-              extraArgs = "-f"; # Override existing partition
+              extraArgs = [ "-f" ]; # Override existing partition
               subvolumes = {
                 # Subvolume name is different from mountpoint
                 "/rootfs" = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -11,8 +11,8 @@ let
       disko-config = import configFile;
     in
     {
-      "${name}-tsp-create" = pkgs.writeScript "create" ((pkgs.callPackage ../. { }).create disko-config);
-      "${name}-tsp-mount" = pkgs.writeScript "mount" ((pkgs.callPackage ../. { }).mount disko-config);
+      "${name}-tsp-create" = (pkgs.callPackage ../. { checked = true; }).createScript disko-config pkgs;
+      "${name}-tsp-mount" = (pkgs.callPackage ../. { checked = true; }).mountScript disko-config pkgs;
     };
 
   allTestFilenames =

--- a/types/btrfs.nix
+++ b/types/btrfs.nix
@@ -7,9 +7,9 @@
       description = "Type";
     };
     extraArgs = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = "Arguments to pass to BTRFS";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments";
     };
     mountOptions = lib.mkOption {
       type = lib.types.listOf lib.types.str;
@@ -37,7 +37,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = { dev }: ''
-        mkfs.btrfs ${dev} ${config.extraArgs}
+        mkfs.btrfs ${dev} ${toString config.extraArgs}
         ${lib.concatMapStrings (subvol: subvol._create { inherit dev; }) (lib.attrValues config.subvolumes)}
       '';
     };

--- a/types/btrfs_subvol.nix
+++ b/types/btrfs_subvol.nix
@@ -13,9 +13,9 @@
       description = "Type";
     };
     extraArgs = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = "Extra arguments to pass";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments";
     };
     mountOptions = lib.mkOption {
       type = lib.types.listOf lib.types.str;
@@ -41,7 +41,7 @@
         (
           mount ${dev} "$MNTPOINT" -o subvol=/
           trap 'umount $MNTPOINT; rm -rf $MNTPOINT' EXIT
-          btrfs subvolume create "$MNTPOINT"/${config.name} ${config.extraArgs}
+          btrfs subvolume create "$MNTPOINT"/${config.name} ${toString config.extraArgs}
         )
       '';
     };

--- a/types/default.nix
+++ b/types/default.nix
@@ -193,6 +193,15 @@ rec {
         description = "Mount script";
       };
 
+    /* Writer for optionally checking bash scripts before writing them to the store
+
+       writeCheckedBash :: AttrSet -> str -> str -> derivation
+    */
+    writeCheckedBash = { pkgs, checked ? false, noDeps ? false }: pkgs.writers.makeScriptWriter {
+      interpreter = if noDeps then "/usr/bin/env bash" else "${pkgs.bash}/bin/bash";
+      check = lib.optionalString checked "${pkgs.shellcheck}/bin/shellcheck";
+    };
+
 
     /* Takes a disko device specification, returns an attrset with metadata
 

--- a/types/default.nix
+++ b/types/default.nix
@@ -199,7 +199,7 @@ rec {
     */
     writeCheckedBash = { pkgs, checked ? false, noDeps ? false }: pkgs.writers.makeScriptWriter {
       interpreter = if noDeps then "/usr/bin/env bash" else "${pkgs.bash}/bin/bash";
-      check = lib.optionalString checked "${pkgs.shellcheck}/bin/shellcheck";
+      check = lib.optionalString checked "${pkgs.shellcheck}/bin/shellcheck -e SC2034";
     };
 
 
@@ -252,6 +252,7 @@ rec {
       set -efux
       umount -Rv "${rootMountPoint}" || :
 
+      # shellcheck disable=SC2043
       for dev in ${toString (lib.catAttrs "device" (lib.attrValues devices.disk))}; do
         ${../disk-deactivate}/disk-deactivate "$dev" | bash -x
       done

--- a/types/filesystem.nix
+++ b/types/filesystem.nix
@@ -7,9 +7,9 @@
       description = "Type";
     };
     extraArgs = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = "Arguments to pass";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments";
     };
     mountOptions = lib.mkOption {
       type = lib.types.listOf lib.types.str;
@@ -35,7 +35,7 @@
       inherit config options;
       default = { dev }: ''
         mkfs.${config.format} \
-          ${config.extraArgs} \
+          ${toString config.extraArgs} \
           ${dev}
       '';
     };

--- a/types/lvm_lv.nix
+++ b/types/lvm_lv.nix
@@ -22,8 +22,8 @@
       description = "LVM type";
     };
     extraArgs = lib.mkOption {
-      type = lib.types.str;
-      default = "";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
       description = "Extra arguments";
     };
     content = diskoLib.partitionType;
@@ -43,7 +43,7 @@
           ${if lib.hasInfix "%" config.size then "-l" else "-L"} ${config.size} \
           -n ${config.name} \
           ${lib.optionalString (config.lvm_type != null) "--type=${config.lvm_type}"} \
-          ${config.extraArgs} \
+          ${toString config.extraArgs} \
           ${vg}
         ${lib.optionalString (config.content != null) (config.content._create {dev = "/dev/${vg}/${config.name}";})}
       '';

--- a/types/lvm_pv.nix
+++ b/types/lvm_pv.nix
@@ -23,7 +23,7 @@
       inherit config options;
       default = { dev }: ''
         pvcreate ${dev}
-        echo "${dev}" >> $disko_devices_dir/lvm_${config.vg}
+        echo "${dev}" >> "$disko_devices_dir"/lvm_${config.vg}
       '';
     };
     _mount = diskoLib.mkMountOption {

--- a/types/lvm_vg.nix
+++ b/types/lvm_vg.nix
@@ -27,7 +27,9 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = _: ''
-        vgcreate ${config.name} $(tr '\n' ' ' < $disko_devices_dir/lvm_${config.name})
+        readarray -t lvm_devices < <(cat "$disko_devices_dir"/lvm_${config.name})
+        vgcreate ${config.name} \
+        "''${lvm_devices[@]}"
         ${lib.concatMapStrings (lv: lv._create {vg = config.name; }) (lib.attrValues config.lvs)}
       '';
     };

--- a/types/mdadm.nix
+++ b/types/mdadm.nix
@@ -34,13 +34,14 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = _: ''
+        readarray -t disk_devices < <(cat "$disko_devices_dir"/raid_${config.name})
         echo 'y' | mdadm --create /dev/md/${config.name} \
           --level=${toString config.level} \
-          --raid-devices=$(wc -l $disko_devices_dir/raid_${config.name} | cut -f 1 -d " ") \
+          --raid-devices="$(wc -l "$disko_devices_dir"/raid_${config.name} | cut -f 1 -d " ")" \
           --metadata=${config.metadata} \
           --force \
           --homehost=any \
-          $(tr '\n' ' ' < $disko_devices_dir/raid_${config.name})
+          "''${disk_devices[@]}"
         udevadm trigger --subsystem-match=block; udevadm settle
         ${lib.optionalString (config.content != null) (config.content._create {dev = "/dev/md/${config.name}";})}
       '';

--- a/types/mdraid.nix
+++ b/types/mdraid.nix
@@ -23,7 +23,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = { dev }: ''
-        echo "${dev}" >> $disko_devices_dir/raid_${config.name}
+        echo "${dev}" >> "$disko_devices_dir"/raid_${config.name}
       '';
     };
     _mount = diskoLib.mkMountOption {

--- a/types/zfs.nix
+++ b/types/zfs.nix
@@ -22,7 +22,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = { dev }: ''
-        echo "${dev}" >> $disko_devices_dir/zfs_${config.pool}
+        echo "${dev}" >> "$disko_devices_dir"/zfs_${config.pool}
       '';
     };
     _mount = diskoLib.mkMountOption {

--- a/types/zpool.nix
+++ b/types/zpool.nix
@@ -52,11 +52,12 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = _: ''
+        readarray -t zfs_devices < <(cat "$disko_devices_dir"/zfs_${config.name})
         zpool create ${config.name} \
           ${config.mode} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
-          $(tr '\n' ' ' < $disko_devices_dir/zfs_${config.name})
+          "''${zfs_devices[@]}"
         ${lib.concatMapStrings (dataset: dataset._create {zpool = config.name;}) (lib.attrValues config.datasets)}
       '';
     };


### PR DESCRIPTION
This is a draft because most generated scripts do not pass shellcheck and I want to make sure this approach is reasonable before fixing (or silencing) all of the little nits this finds

I had originally implemented it as a check run in the VM since that is a much simpler change, but I figured people may want to opt-in to having their scripts checked as they are generated (and also it is easier to get errors and fix that way when it's implemented as a checkPhase to the derivation rather than run in a VM way down the line)

(Also I may still change this approach -- I only wrote this in the last hour or two and tend to change my mind after a first implementation, but feedback is very welcome)