### PR TITLE
Revert "don't use bot token for flake updates"

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v16
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pr-body: |
             Automated changes by the update-flake-lock
             ```


### PR DESCRIPTION
This reverts commit c681875a0c17f6e7baf4f398809be3790189be1c.

That did not quite work, but now we have our own bot for disko.