### PR TITLE
Standardise formatting with nixpkgs-fmt and some patterns with statix 

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,7 @@
 let
-  pkgs = import <nixpkgs> {};
-in {
+  pkgs = import <nixpkgs> { };
+in
+{
   test = pkgs.writeScript "test" ''
     #!/bin/sh
     nix-build "${toString ./tests}";

--- a/cli.nix
+++ b/cli.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}
+{ pkgs ? import <nixpkgs> { }
 , lib ? pkgs.lib
 , mode ? "mount"
 , flake ? null
@@ -6,35 +6,39 @@
 , diskoFile ? null
 , rootMountPoint ? "/mnt"
 , noDeps ? false
-, ... }@args:
+, ...
+}@args:
 let
   disko = import ./. {
     inherit rootMountPoint;
     inherit lib;
   };
 
-  diskFormat = if flake != null then
-    (pkgs.lib.attrByPath [ "diskoConfigurations" flakeAttr ] (builtins.abort "${flakeAttr} does not exist") (builtins.getFlake flake)) args
-  else
-    import diskoFile ({ inherit lib; } // args);
+  diskFormat =
+    if flake != null then
+      (pkgs.lib.attrByPath [ "diskoConfigurations" flakeAttr ] (builtins.abort "${flakeAttr} does not exist") (builtins.getFlake flake)) args
+    else
+      import diskoFile ({ inherit lib; } // args);
 
-  diskoEval = if noDeps then
-    if (mode == "create") then
-      disko.createScriptNoDeps diskFormat pkgs
-    else if (mode == "mount") then
-      disko.mountScriptNoDeps diskFormat pkgs
-    else if (mode == "zap_create_mount") then
-      disko.zapCreateMountScriptNoDeps diskFormat pkgs
+  diskoEval =
+    if noDeps then
+      if (mode == "create") then
+        disko.createScriptNoDeps diskFormat pkgs
+      else if (mode == "mount") then
+        disko.mountScriptNoDeps diskFormat pkgs
+      else if (mode == "zap_create_mount") then
+        disko.zapCreateMountScriptNoDeps diskFormat pkgs
+      else
+        builtins.abort "invalid mode"
     else
-      builtins.abort "invalid mode"
-  else
-    if (mode == "create") then
-      disko.createScript diskFormat pkgs
-    else if (mode == "mount") then
-      disko.mountScript diskFormat pkgs
-    else if (mode == "zap_create_mount") then
-      disko.zapCreateMountScript diskFormat pkgs
-    else
-      builtins.abort "invalid mode"
+      if (mode == "create") then
+        disko.createScript diskFormat pkgs
+      else if (mode == "mount") then
+        disko.mountScript diskFormat pkgs
+      else if (mode == "zap_create_mount") then
+        disko.zapCreateMountScript diskFormat pkgs
+      else
+        builtins.abort "invalid mode"
   ;
-in diskoEval
+in
+diskoEval

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,9 @@ let
       };
     };
   };
-in {
-  types = types;
+in
+{
+  inherit types;
   create = cfg: types.diskoLib.create (eval cfg).config.devices;
   createScript = cfg: pkgs: pkgs.writeScript "disko-create" ''
     #!/usr/bin/env bash

--- a/doc.nix
+++ b/doc.nix
@@ -6,12 +6,12 @@ let
     rootMountPoint = "/mnt";
   };
   eval = lib.evalModules {
-    modules =  [
+    modules = [
       {
         options.disko = {
           devices = lib.mkOption {
             type = types.devices;
-            default = {};
+            default = { };
             description = "The devices to set up";
           };
         };
@@ -19,7 +19,7 @@ let
     ];
   };
   options = nixosOptionsDoc {
-    options = eval.options;
+    inherit (eval) options;
   };
   md = (runCommand "disko-options.md" { } ''
     cat >$out <<EOF
@@ -28,14 +28,15 @@ let
     EOF
     cat ${options.optionsCommonMark} >>$out
   '').overrideAttrs (o: {
-     # Work around https://github.com/hercules-ci/hercules-ci-agent/issues/168
-     allowSubstitutes = true;
+    # Work around https://github.com/hercules-ci/hercules-ci-agent/issues/168
+    allowSubstitutes = true;
   });
   css = fetchurl {
     url = "https://gist.githubusercontent.com/killercup/5917178/raw/40840de5352083adb2693dc742e9f75dbb18650f/pandoc.css";
     sha256 = "sha256-SzSvxBIrylxBF6B/mOImLlZ+GvCfpWNLzGFViLyOeTk=";
   };
-in runCommand "disko.html" { nativeBuildInputs = [ pandoc ]; } ''
+in
+runCommand "disko.html" { nativeBuildInputs = [ pandoc ]; } ''
   mkdir $out
   cp ${css} $out/pandoc.css
   pandoc --css="pandoc.css" ${md} --to=html5 -s -f markdown+smart --metadata pagetitle="Disko options" -o $out/index.html

--- a/example/with-lib.nix
+++ b/example/with-lib.nix
@@ -1,7 +1,7 @@
 # Example to create a bios compatible gpt partition
 { disks ? [ "/dev/vdb" ], lib, ... }: {
   disk = lib.genAttrs [ (lib.head disks) ] (device: {
-    device = device;
+    inherit device;
     type = "disk";
     content = {
       type = "table";

--- a/flake.nix
+++ b/flake.nix
@@ -6,49 +6,56 @@
   #inputs.nixpkgs.url = "nixpkgs";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs, ... }: let
-    supportedSystems = [
-      "x86_64-linux"
-      "i686-linux"
-      "aarch64-linux"
-    ];
-    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-  in {
-    nixosModules.disko = import ./module.nix;
-    lib = import ./. {
-      inherit (nixpkgs) lib;
-    };
-    packages = forAllSystems (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      disko = pkgs.callPackage ./package.nix {};
-      disko-doc = pkgs.callPackage ./doc.nix { };
-      default = self.packages.${system}.disko;
-      # The way bcachefs support is maintained in nixpkgs is prone to breakage.
-      # That's why we need to maintain a fork here:
-      # https://github.com/NixOS/nixpkgs/issues/212086
-      linux-bcachefs = pkgs.callPackage ./linux-testing-bcachefs.nix {};
-    });
-    legacyPackages = forAllSystems (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      linuxPackages_bcachefs = pkgs.linuxPackagesFor self.packages.${pkgs.system}.linux-bcachefs;
-    });
-    # TODO: disable bios-related tests on aarch64...
-    # Run checks: nix flake check -L
-    checks = forAllSystems (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      nixosTests = import ./tests {
-        inherit pkgs;
-        makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
-        eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
-      };
-      shellcheck = pkgs.runCommand "shellcheck" { nativeBuildInputs =  [ pkgs.shellcheck ]; } ''
-        cd ${./.}
-        shellcheck disk-deactivate/disk-deactivate disko
-        touch $out
-      '';
+  outputs = { self, nixpkgs, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "i686-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
-      nixosTests // { inherit shellcheck; });
-  };
+    {
+      nixosModules.disko = import ./module.nix;
+      lib = import ./. {
+        inherit (nixpkgs) lib;
+      };
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          disko = pkgs.callPackage ./package.nix { };
+          disko-doc = pkgs.callPackage ./doc.nix { };
+          default = self.packages.${system}.disko;
+          # The way bcachefs support is maintained in nixpkgs is prone to breakage.
+          # That's why we need to maintain a fork here:
+          # https://github.com/NixOS/nixpkgs/issues/212086
+          linux-bcachefs = pkgs.callPackage ./linux-testing-bcachefs.nix { };
+        });
+      legacyPackages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          linuxPackages_bcachefs = pkgs.linuxPackagesFor self.packages.${pkgs.system}.linux-bcachefs;
+        });
+      # TODO: disable bios-related tests on aarch64...
+      # Run checks: nix flake check -L
+      checks = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          nixosTests = import ./tests {
+            inherit pkgs;
+            makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
+            eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
+          };
+          shellcheck = pkgs.runCommand "shellcheck" { nativeBuildInputs = [ pkgs.shellcheck ]; } ''
+            cd ${./.}
+            shellcheck disk-deactivate/disk-deactivate disko
+            touch $out
+          '';
+        in
+        nixosTests // { inherit shellcheck; });
+    };
 }

--- a/linux-testing-bcachefs.nix
+++ b/linux-testing-bcachefs.nix
@@ -18,11 +18,11 @@ buildLinux (args // {
     sha256 = "sha256-n00qPtHHEHt3FSIRMoP9IJFAdQJNNwabg+WAKppSAS8=";
   };
 
-  kernelPatches = (args.kernelPatches or []) ++ [{
+  kernelPatches = (args.kernelPatches or [ ]) ++ [{
     name = "bcachefs-config";
     patch = null;
     extraConfig = ''
       BCACHEFS_FS m
     '';
   }];
-} // (args.argsOverride or {}))
+} // (args.argsOverride or { }))

--- a/module.nix
+++ b/module.nix
@@ -2,14 +2,15 @@
 let
   types = import ./types {
     inherit lib;
-    rootMountPoint = config.disko.rootMountPoint;
+    inherit (config.disko) rootMountPoint;
   };
   cfg = config.disko;
-in {
+in
+{
   options.disko = {
     devices = lib.mkOption {
       type = types.devices;
-      default = {};
+      default = { };
       description = "The devices to set up";
     };
     rootMountPoint = lib.mkOption {
@@ -27,7 +28,7 @@ in {
       default = true;
     };
   };
-  config = lib.mkIf (cfg.devices.disk != {}) {
+  config = lib.mkIf (cfg.devices.disk != { }) {
     system.build.formatScript = pkgs.writers.writeBash "disko-create" ''
       export PATH=${lib.makeBinPath (types.diskoLib.packages cfg.devices pkgs)}:$PATH
       ${types.diskoLib.create cfg.devices}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3,8 +3,8 @@
 , pkgs ? (import <nixpkgs> { })
 }@args:
 let
-  lib = pkgs.lib;
-  makeDiskoTest = (pkgs.callPackage ./lib.nix { inherit makeTest eval-config; }).makeDiskoTest;
+  inherit (pkgs) lib;
+  inherit ((pkgs.callPackage ./lib.nix { inherit makeTest eval-config; })) makeDiskoTest;
 
   evalTest = name: configFile: let
     disko-config = import configFile;
@@ -20,7 +20,7 @@ let
         (lib.attrNames (builtins.readDir ./.))
     );
 
-  allTests = lib.genAttrs (allTestFilenames) (test: import (./. + "/${test}.nix") { inherit makeDiskoTest pkgs; }) //
+  allTests = lib.genAttrs allTestFilenames (test: import (./. + "/${test}.nix") { inherit makeDiskoTest pkgs; }) //
              evalTest "lvm-luks-example" ../example/config.nix // {
                standalone = (pkgs.nixos [ ../example/stand-alone/configuration.nix ]).config.system.build.toplevel;
              };

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -17,7 +17,7 @@
     , testBoot ? true # if we actually want to test booting or just create/mount
     }:
     let
-      lib = pkgs.lib;
+      inherit (pkgs) lib;
       makeTest' = args:
         makeTest args {
           inherit pkgs;

--- a/types/btrfs.nix
+++ b/types/btrfs.nix
@@ -48,7 +48,7 @@
           subvolMounts = diskoLib.deepMergeMap (subvol: subvol._mount { inherit dev; parent = config.mountpoint; }) (lib.attrValues config.subvolumes);
         in
         {
-          fs = subvolMounts.fs // lib.optionalAttrs (!isNull config.mountpoint) {
+          fs = subvolMounts.fs // lib.optionalAttrs (config.mountpoint != null) {
             ${config.mountpoint} = ''
               if ! findmnt ${dev} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
                 mount ${dev} "${rootMountPoint}${config.mountpoint}" \
@@ -64,7 +64,7 @@
       readOnly = true;
       default = dev: [
         (map (subvol: subvol._config dev config.mountpoint) (lib.attrValues config.subvolumes))
-        (lib.optional (!isNull config.mountpoint) {
+        (lib.optional (config.mountpoint != null) {
           fileSystems.${config.mountpoint} = {
             device = dev;
             fsType = "btrfs";

--- a/types/btrfs_subvol.nix
+++ b/types/btrfs_subvol.nix
@@ -50,11 +50,11 @@
       default = { dev, parent }:
         let
           mountpoint =
-            if (!isNull config.mountpoint) then config.mountpoint
-            else if (isNull parent) then config.name
+            if (config.mountpoint != null) then config.mountpoint
+            else if (parent == null) then config.name
             else null;
         in
-        lib.optionalAttrs (!isNull mountpoint) {
+        lib.optionalAttrs (mountpoint != null) {
           fs.${mountpoint} = ''
             if ! findmnt ${dev} "${rootMountPoint}${mountpoint}" > /dev/null 2>&1; then
               mount ${dev} "${rootMountPoint}${mountpoint}" \
@@ -70,11 +70,11 @@
       default = dev: parent:
         let
           mountpoint =
-            if (!isNull config.mountpoint) then config.mountpoint
-            else if (isNull parent) then config.name
+            if (config.mountpoint != null) then config.mountpoint
+            else if (parent == null) then config.name
             else null;
         in
-        lib.optional (!isNull mountpoint) {
+        lib.optional (mountpoint != null) {
           fileSystems.${mountpoint} = {
             device = dev;
             fsType = "btrfs";

--- a/types/disk.nix
+++ b/types/disk.nix
@@ -22,30 +22,30 @@
       readOnly = true;
       type = diskoLib.jsonType;
       default =
-        lib.optionalAttrs (!isNull config.content) (config.content._meta [ "disk" config.device ]);
+        lib.optionalAttrs (config.content != null) (config.content._meta [ "disk" config.device ]);
       description = "Metadata";
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
-      default = {}: config.content._create { dev = config.device; };
+      default = _: config.content._create { dev = config.device; };
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
-      default = {}:
-        lib.optionalAttrs (!isNull config.content) (config.content._mount { dev = config.device; });
+      default = _:
+        lib.optionalAttrs (config.content != null) (config.content._mount { dev = config.device; });
     };
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
       default =
-        lib.optional (!isNull config.content) (config.content._config config.device);
+        lib.optional (config.content != null) (config.content._config config.device);
       description = "NixOS configuration";
     };
     _pkgs = lib.mkOption {
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: [ pkgs.jq ] ++ lib.optionals (!isNull config.content) (config.content._pkgs pkgs);
+      default = pkgs: [ pkgs.jq ] ++ lib.optionals (config.content != null) (config.content._pkgs pkgs);
       description = "Packages";
     };
   };

--- a/types/luks.nix
+++ b/types/luks.nix
@@ -26,15 +26,15 @@
       readOnly = true;
       type = lib.types.functionTo diskoLib.jsonType;
       default = dev:
-        lib.optionalAttrs (!isNull config.content) (config.content._meta dev);
+        lib.optionalAttrs (config.content != null) (config.content._meta dev);
       description = "Metadata";
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = { dev }: ''
         cryptsetup -q luksFormat ${dev} ${diskoLib.maybeStr config.keyFile} ${toString config.extraArgs}
-        cryptsetup luksOpen ${dev} ${config.name} ${lib.optionalString (!isNull config.keyFile) "--key-file ${config.keyFile}"}
-        ${lib.optionalString (!isNull config.content) (config.content._create {dev = "/dev/mapper/${config.name}";})}
+        cryptsetup luksOpen ${dev} ${config.name} ${lib.optionalString (config.keyFile != null) "--key-file ${config.keyFile}"}
+        ${lib.optionalString (config.content != null) (config.content._create {dev = "/dev/mapper/${config.name}";})}
       '';
     };
     _mount = diskoLib.mkMountOption {
@@ -46,10 +46,10 @@
         {
           dev = ''
             cryptsetup status ${config.name} >/dev/null 2>/dev/null ||
-              cryptsetup luksOpen ${dev} ${config.name} ${lib.optionalString (!isNull config.keyFile) "--key-file ${config.keyFile}"}
-            ${lib.optionalString (!isNull config.content) contentMount.dev or ""}
+              cryptsetup luksOpen ${dev} ${config.name} ${lib.optionalString (config.keyFile != null) "--key-file ${config.keyFile}"}
+            ${lib.optionalString (config.content != null) contentMount.dev or ""}
           '';
-          fs = lib.optionalAttrs (!isNull config.content) contentMount.fs or { };
+          fs = lib.optionalAttrs (config.content != null) contentMount.fs or { };
         };
     };
     _config = lib.mkOption {
@@ -59,14 +59,14 @@
         [
           # TODO do we need this always in initrd and only there?
           { boot.initrd.luks.devices.${config.name}.device = dev; }
-        ] ++ (lib.optional (!isNull config.content) (config.content._config "/dev/mapper/${config.name}"));
+        ] ++ (lib.optional (config.content != null) (config.content._config "/dev/mapper/${config.name}"));
       description = "NixOS configuration";
     };
     _pkgs = lib.mkOption {
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: [ pkgs.cryptsetup ] ++ (lib.optionals (!isNull config.content) (config.content._pkgs pkgs));
+      default = pkgs: [ pkgs.cryptsetup ] ++ (lib.optionals (config.content != null) (config.content._pkgs pkgs));
       description = "Packages";
     };
   };

--- a/types/lvm_lv.nix
+++ b/types/lvm_lv.nix
@@ -32,7 +32,7 @@
       readOnly = true;
       type = lib.types.functionTo diskoLib.jsonType;
       default = dev:
-        lib.optionalAttrs (!isNull config.content) (config.content._meta dev);
+        lib.optionalAttrs (config.content != null) (config.content._meta dev);
       description = "Metadata";
     };
     _create = diskoLib.mkCreateOption {
@@ -42,24 +42,24 @@
           --yes \
           ${if lib.hasInfix "%" config.size then "-l" else "-L"} ${config.size} \
           -n ${config.name} \
-          ${lib.optionalString (!isNull config.lvm_type) "--type=${config.lvm_type}"} \
+          ${lib.optionalString (config.lvm_type != null) "--type=${config.lvm_type}"} \
           ${config.extraArgs} \
           ${vg}
-        ${lib.optionalString (!isNull config.content) (config.content._create {dev = "/dev/${vg}/${config.name}";})}
+        ${lib.optionalString (config.content != null) (config.content._create {dev = "/dev/${vg}/${config.name}";})}
       '';
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
       default = { vg }:
-        lib.optionalAttrs (!isNull config.content) (config.content._mount { dev = "/dev/${vg}/${config.name}"; });
+        lib.optionalAttrs (config.content != null) (config.content._mount { dev = "/dev/${vg}/${config.name}"; });
     };
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
       default = vg:
         [
-          (lib.optional (!isNull config.content) (config.content._config "/dev/${vg}/${config.name}"))
-          (lib.optional (!isNull config.lvm_type) {
+          (lib.optional (config.content != null) (config.content._config "/dev/${vg}/${config.name}"))
+          (lib.optional (config.lvm_type != null) {
             boot.initrd.kernelModules = [ "dm-${config.lvm_type}" ];
           })
         ];
@@ -69,7 +69,7 @@
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: lib.optionals (!isNull config.content) (config.content._pkgs pkgs);
+      default = pkgs: lib.optionals (config.content != null) (config.content._pkgs pkgs);
       description = "Packages";
     };
   };

--- a/types/lvm_vg.nix
+++ b/types/lvm_vg.nix
@@ -26,14 +26,14 @@
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
-      default = {}: ''
+      default = _: ''
         vgcreate ${config.name} $(tr '\n' ' ' < $disko_devices_dir/lvm_${config.name})
         ${lib.concatMapStrings (lv: lv._create {vg = config.name; }) (lib.attrValues config.lvs)}
       '';
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
-      default = {}:
+      default = _:
         let
           lvMounts = diskoLib.deepMergeMap (lv: lv._mount { vg = config.name; }) (lib.attrValues config.lvs);
         in
@@ -42,7 +42,7 @@
             vgchange -a y
             ${lib.concatMapStrings (x: x.dev or "") (lib.attrValues lvMounts)}
           '';
-          fs = lvMounts.fs;
+          inherit (lvMounts) fs;
         };
     };
     _config = lib.mkOption {

--- a/types/mdadm.nix
+++ b/types/mdadm.nix
@@ -28,12 +28,12 @@
       readOnly = true;
       type = diskoLib.jsonType;
       default =
-        lib.optionalAttrs (!isNull config.content) (config.content._meta [ "mdadm" config.name ]);
+        lib.optionalAttrs (config.content != null) (config.content._meta [ "mdadm" config.name ]);
       description = "Metadata";
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
-      default = {}: ''
+      default = _: ''
         echo 'y' | mdadm --create /dev/md/${config.name} \
           --level=${toString config.level} \
           --raid-devices=$(wc -l $disko_devices_dir/raid_${config.name} | cut -f 1 -d " ") \
@@ -42,27 +42,27 @@
           --homehost=any \
           $(tr '\n' ' ' < $disko_devices_dir/raid_${config.name})
         udevadm trigger --subsystem-match=block; udevadm settle
-        ${lib.optionalString (!isNull config.content) (config.content._create {dev = "/dev/md/${config.name}";})}
+        ${lib.optionalString (config.content != null) (config.content._create {dev = "/dev/md/${config.name}";})}
       '';
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
-      default = {}:
-        lib.optionalAttrs (!isNull config.content) (config.content._mount { dev = "/dev/md/${config.name}"; });
+      default = _:
+        lib.optionalAttrs (config.content != null) (config.content._mount { dev = "/dev/md/${config.name}"; });
       # TODO we probably need to assemble the mdadm somehow
     };
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
       default =
-        lib.optional (!isNull config.content) (config.content._config "/dev/md/${config.name}");
+        lib.optional (config.content != null) (config.content._config "/dev/md/${config.name}");
       description = "NixOS configuration";
     };
     _pkgs = lib.mkOption {
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: (lib.optionals (!isNull config.content) (config.content._pkgs pkgs));
+      default = pkgs: (lib.optionals (config.content != null) (config.content._pkgs pkgs));
       description = "Packages";
     };
   };

--- a/types/nodev.nix
+++ b/types/nodev.nix
@@ -35,11 +35,11 @@
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
-      default = {}: "";
+      default = _: "";
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
-      default = {}: {
+      default = _: {
         fs.${config.mountpoint} = ''
           if ! findmnt ${config.fsType} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
             mount -t ${config.fsType} ${config.device} "${rootMountPoint}${config.mountpoint}" \
@@ -54,8 +54,8 @@
       readOnly = true;
       default = [{
         fileSystems.${config.mountpoint} = {
-          device = config.device;
-          fsType = config.fsType;
+          inherit (config) device;
+          inherit (config) fsType;
           options = config.mountOptions;
         };
       }];

--- a/types/partition.nix
+++ b/types/partition.nix
@@ -52,7 +52,7 @@
       readOnly = true;
       type = lib.types.functionTo diskoLib.jsonType;
       default = dev:
-        lib.optionalAttrs (!isNull config.content) (config.content._meta dev);
+        lib.optionalAttrs (config.content != null) (config.content._meta dev);
       description = "Metadata";
     };
     _create = diskoLib.mkCreateOption {
@@ -66,7 +66,7 @@
         ''}
         # ensure /dev/disk/by-path/..-partN exists before continuing
         udevadm trigger --subsystem-match=block; udevadm settle
-        ${lib.optionalString (config.bootable) ''
+        ${lib.optionalString config.bootable ''
           parted -s ${dev} -- set ${toString config.index} boot on
         ''}
         ${lib.concatMapStringsSep "" (flag: ''
@@ -74,26 +74,26 @@
         '') config.flags}
         # ensure further operations can detect new partitions
         udevadm trigger --subsystem-match=block; udevadm settle
-        ${lib.optionalString (!isNull config.content) (config.content._create {dev = (diskoLib.deviceNumbering dev config.index);})}
+        ${lib.optionalString (config.content != null) (config.content._create {dev = diskoLib.deviceNumbering dev config.index;})}
       '';
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
       default = { dev }:
-        lib.optionalAttrs (!isNull config.content) (config.content._mount { dev = (diskoLib.deviceNumbering dev config.index); });
+        lib.optionalAttrs (config.content != null) (config.content._mount { dev = diskoLib.deviceNumbering dev config.index; });
     };
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
       default = dev:
-        lib.optional (!isNull config.content) (config.content._config (diskoLib.deviceNumbering dev config.index));
+        lib.optional (config.content != null) (config.content._config (diskoLib.deviceNumbering dev config.index));
       description = "NixOS configuration";
     };
     _pkgs = lib.mkOption {
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: lib.optionals (!isNull config.content) (config.content._pkgs pkgs);
+      default = pkgs: lib.optionals (config.content != null) (config.content._pkgs pkgs);
       description = "Packages";
     };
   };

--- a/types/swap.nix
+++ b/types/swap.nix
@@ -40,7 +40,7 @@
       default = dev: [{
         swapDevices = [{
           device = dev;
-          randomEncryption = config.randomEncryption;
+          inherit (config) randomEncryption;
         }];
       }];
       description = "NixOS configuration";

--- a/types/zfs_dataset.nix
+++ b/types/zfs_dataset.nix
@@ -47,7 +47,7 @@
       readOnly = true;
       type = lib.types.functionTo diskoLib.jsonType;
       default = dev:
-        lib.optionalAttrs (!isNull config.content) (config.content._meta dev);
+        lib.optionalAttrs (config.content != null) (config.content._meta dev);
       description = "Metadata";
     };
     _create = diskoLib.mkCreateOption {
@@ -58,14 +58,14 @@
           ${lib.optionalString (config.zfs_type == "volume") "-V ${config.size}"}
         ${lib.optionalString (config.zfs_type == "volume") ''
           udevadm trigger --subsystem-match=block; udevadm settle
-          ${lib.optionalString (!isNull config.content) (config.content._create {dev = "/dev/zvol/${zpool}/${config.name}";})}
+          ${lib.optionalString (config.content != null) (config.content._create {dev = "/dev/zvol/${zpool}/${config.name}";})}
         ''}
       '';
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
       default = { zpool }:
-        lib.optionalAttrs (config.zfs_type == "volume" && !isNull config.content) (config.content._mount { dev = "/dev/zvol/${zpool}/${config.name}"; }) //
+        lib.optionalAttrs (config.zfs_type == "volume" && config.content != null) (config.content._mount { dev = "/dev/zvol/${zpool}/${config.name}"; }) //
         lib.optionalAttrs (config.zfs_type == "filesystem" && config.options.mountpoint or "" != "none") {
           fs.${config.mountpoint} = ''
             if ! findmnt ${zpool}/${config.name} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
@@ -82,7 +82,7 @@
       internal = true;
       readOnly = true;
       default = zpool:
-        (lib.optional (config.zfs_type == "volume" && !isNull config.content) (config.content._config "/dev/zvol/${zpool}/${config.name}")) ++
+        (lib.optional (config.zfs_type == "volume" && config.content != null) (config.content._config "/dev/zvol/${zpool}/${config.name}")) ++
         (lib.optional (config.zfs_type == "filesystem" && config.options.mountpoint or "" != "none") {
           fileSystems.${config.mountpoint} = {
             device = "${zpool}/${config.name}";
@@ -96,7 +96,7 @@
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: [ pkgs.util-linux ] ++ lib.optionals (!isNull config.content) (config.content._pkgs pkgs);
+      default = pkgs: [ pkgs.util-linux ] ++ lib.optionals (config.content != null) (config.content._pkgs pkgs);
       description = "Packages";
     };
   };


### PR DESCRIPTION
Perhaps a bit controversial, and a bit subjective, so please feel free to shoot down if it doesn't align with the maintainers point of view.

I'm a big fan of the [black] style of formatting; 

> _Black_ is the uncompromising Python code formatter. By using it, you agree to cede
> control over minutiae of hand-formatting. In return, _Black_ gives you speed,
> determinism, and freedom from `pycodestyle` nagging about formatting. You will save time
> and mental energy for more important matters.
> 
> Blackened code looks the same regardless of the project you're reading. Formatting
> becomes transparent after a while and you can focus on the content instead.
> 
> _Black_ makes code review faster by producing the smallest diffs possible.

`statix` goes a little further by normalising some standard patterns, but using it here with a similar philosophy, i.e. if two ways of doing things are, more or less the same, just pick which other one is most standard and leave me out of it.

There's nothing quite as universal as PEP8 or `black` in the Nix ecosystem (as far as I know anyway), so it doesn't quite provide the same level of "looks the same regardless of the project you're reading", but these both seem common enough to be part way there, and hopefully make it easier for potential contributors to read the existing code.

Even without the wider standardisation in the nix ecosystem, it still makes it easier to contribute to this project if one can just run a quick command against the code before submitting the PR and know that they're aligning with the conventions of the project. 

In this case I just ran;

```sh
nixpkgs-fmt **.nix && statix fix .
```

`nixpkgs-fmt` and `statix`  are my gotos just for [Ale](https://github.com/dense-analysis/ale)/vim integration, and due to the relative ease of autofixing on the command line, but I'd be happy with alternatives following the same philosophy. Or perhaps there's already a soft-convention in use in the repo that I've missed!

Anyway like I say, no biggie if it's an unpopular idea! I don't want to step on any toes, but just wanted to suggest it as someone thinking about contributing (if I find the time!). 

[black]: https://github.com/psf/black#the-uncompromising-code-formatter