### PR TITLE
ci: remove unneeded github token

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -12,9 +12,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v19
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v16
         with:


### PR DESCRIPTION
v19 of the action has a default token that works well