### PR TITLE
style: Add config for style normalisation and re-apply

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ let
   };
 in
 {
-  inherit types;
+  types = types;
   create = cfg: types.diskoLib.create (eval cfg).config.devices;
   createScript = cfg: pkgs: pkgs.writeScript "disko-create" ''
     #!/usr/bin/env bash

--- a/doc.nix
+++ b/doc.nix
@@ -19,7 +19,7 @@ let
     ];
   };
   options = nixosOptionsDoc {
-    inherit (eval) options;
+    options = eval.options;
   };
   md = (runCommand "disko-options.md" { } ''
     cat >$out <<EOF

--- a/example/boot-raid1.nix
+++ b/example/boot-raid1.nix
@@ -13,7 +13,7 @@
             start = "0";
             end = "1M";
             part-type = "primary";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
           }
           {
             type = "partition";
@@ -53,7 +53,7 @@
             start = "0";
             end = "1M";
             part-type = "primary";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
           }
           {
             type = "partition";

--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -35,12 +35,12 @@
                 };
                 # Mountpoints inferred from subvolume name
                 "/home" = {
-                  mountOptions = ["compress=zstd"];
+                  mountOptions = [ "compress=zstd" ];
                 };
                 "/nix" = {
-                  mountOptions = ["compress=zstd" "noatime"];
+                  mountOptions = [ "compress=zstd" "noatime" ];
                 };
-                "/test" = {};
+                "/test" = { };
               };
             };
           }

--- a/example/config.nix
+++ b/example/config.nix
@@ -51,7 +51,7 @@
             part-type = "primary";
             start = "1024MiB";
             end = "100%";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
             content = {
               type = "luks";
               name = "crypted";

--- a/example/gpt-bios-compat.nix
+++ b/example/gpt-bios-compat.nix
@@ -14,7 +14,7 @@
             start = "0";
             end = "1M";
             part-type = "primary";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
           }
           {
             name = "root";

--- a/example/hybrid.nix
+++ b/example/hybrid.nix
@@ -13,7 +13,7 @@
             type = "partition";
             start = "0";
             end = "1M";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
           }
           {
             type = "partition";

--- a/example/mdadm.nix
+++ b/example/mdadm.nix
@@ -13,7 +13,7 @@
             start = "0";
             end = "1M";
             part-type = "primary";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
           }
           {
             type = "partition";
@@ -41,7 +41,7 @@
             start = "0";
             end = "1M";
             part-type = "primary";
-            flags = ["bios_grub"];
+            flags = [ "bios_grub" ];
           }
           {
             type = "partition";

--- a/example/stand-alone/configuration.nix
+++ b/example/stand-alone/configuration.nix
@@ -1,8 +1,8 @@
-{
-  pkgs,
-  lib,
-  ...
-}: let
+{ pkgs
+, lib
+, ...
+}:
+let
   # We just import from the repository for testing here:
   disko = import ../../. {
     inherit lib;
@@ -41,7 +41,8 @@
       };
     };
   };
-in {
+in
+{
   imports = [
     (disko.config cfg)
   ];

--- a/example/with-lib.nix
+++ b/example/with-lib.nix
@@ -1,7 +1,7 @@
 # Example to create a bios compatible gpt partition
 { disks ? [ "/dev/vdb" ], lib, ... }: {
   disk = lib.genAttrs [ (lib.head disks) ] (device: {
-    inherit device;
+    device = device;
     type = "disk";
     content = {
       type = "table";

--- a/example/with-lib.nix
+++ b/example/with-lib.nix
@@ -13,7 +13,7 @@
           start = "0";
           end = "1M";
           part-type = "primary";
-          flags = ["bios_grub"];
+          flags = [ "bios_grub" ];
         }
         {
           name = "root";

--- a/flake.nix
+++ b/flake.nix
@@ -57,5 +57,22 @@
           '';
         in
         nixosTests // { inherit shellcheck; });
+      formatter = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        pkgs.writeShellApplication {
+          name = "normalise_nix";
+          runtimeInputs = with pkgs; [
+            nixpkgs-fmt
+            statix
+          ];
+          text = ''
+            set -o xtrace
+            nixpkgs-fmt "$@"
+            statix fix "$@"
+          '';
+        }
+      );
     };
 }

--- a/module.nix
+++ b/module.nix
@@ -2,7 +2,7 @@
 let
   types = import ./types {
     inherit lib;
-    inherit (config.disko) rootMountPoint;
+    rootMountPoint = config.disko.rootMountPoint;
   };
   cfg = config.disko;
 in

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,4 @@
+disabled = [
+    "manual_inherit",  # Prefer `inherit types;` instead of `types = types;`
+    "manual_inherit_from",  # Prefer `inherit (eval) options;` instead of `options = eval.options`.
+]

--- a/tests/bcachefs.nix
+++ b/tests/bcachefs.nix
@@ -2,7 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 let
-  linux-bcachefs = pkgs.callPackage ../linux-testing-bcachefs.nix {};
+  linux-bcachefs = pkgs.callPackage ../linux-testing-bcachefs.nix { };
 in
 makeDiskoTest {
   disko-config = ../example/bcachefs.nix;
@@ -14,11 +14,13 @@ makeDiskoTest {
   extraConfig = {
     boot.supportedFilesystems = [ "bcachefs" ];
     # disable zfs so we can support latest kernel
-    nixpkgs.overlays = [(final: super: {
-      zfs = super.zfs.overrideAttrs(_: {
-        meta.platforms = [];
-      });
-    })];
+    nixpkgs.overlays = [
+      (final: super: {
+        zfs = super.zfs.overrideAttrs (_: {
+          meta.platforms = [ ];
+        });
+      })
+    ];
     boot.kernelPackages = pkgs.lib.mkForce (pkgs.recurseIntoAttrs (pkgs.linuxPackagesFor linux-bcachefs));
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -6,12 +6,14 @@ let
   lib = pkgs.lib;
   makeDiskoTest = (pkgs.callPackage ./lib.nix { inherit makeTest eval-config; }).makeDiskoTest;
 
-  evalTest = name: configFile: let
-    disko-config = import configFile;
-  in {
-    "${name}-tsp-create" = pkgs.writeScript "create" ((pkgs.callPackage ../. { }).create disko-config);
-    "${name}-tsp-mount" = pkgs.writeScript "mount" ((pkgs.callPackage ../. { }).mount disko-config);
-  };
+  evalTest = name: configFile:
+    let
+      disko-config = import configFile;
+    in
+    {
+      "${name}-tsp-create" = pkgs.writeScript "create" ((pkgs.callPackage ../. { }).create disko-config);
+      "${name}-tsp-mount" = pkgs.writeScript "mount" ((pkgs.callPackage ../. { }).mount disko-config);
+    };
 
   allTestFilenames =
     builtins.map (lib.removeSuffix ".nix") (
@@ -21,8 +23,8 @@ let
     );
 
   allTests = lib.genAttrs allTestFilenames (test: import (./. + "/${test}.nix") { inherit makeDiskoTest pkgs; }) //
-             evalTest "lvm-luks-example" ../example/config.nix // {
-               standalone = (pkgs.nixos [ ../example/stand-alone/configuration.nix ]).config.system.build.toplevel;
-             };
+    evalTest "lvm-luks-example" ../example/config.nix // {
+    standalone = (pkgs.nixos [ ../example/stand-alone/configuration.nix ]).config.system.build.toplevel;
+  };
 in
 allTests

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3,8 +3,8 @@
 , pkgs ? (import <nixpkgs> { })
 }@args:
 let
-  inherit (pkgs) lib;
-  inherit ((pkgs.callPackage ./lib.nix { inherit makeTest eval-config; })) makeDiskoTest;
+  lib = pkgs.lib;
+  makeDiskoTest = (pkgs.callPackage ./lib.nix { inherit makeTest eval-config; }).makeDiskoTest;
 
   evalTest = name: configFile: let
     disko-config = import configFile;

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -100,7 +100,7 @@
         documentation.enable = false;
 
         nix.settings = {
-          substituters = lib.mkForce [];
+          substituters = lib.mkForce [ ];
           hashed-mirrors = null;
           connect-timeout = 1;
         };

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -17,7 +17,7 @@
     , testBoot ? true # if we actually want to test booting or just create/mount
     }:
     let
-      inherit (pkgs) lib;
+      lib = pkgs.lib;
       makeTest' = args:
         makeTest args {
           inherit pkgs;

--- a/types/default.nix
+++ b/types/default.nix
@@ -187,7 +187,7 @@ rec {
         internal = true;
         readOnly = true;
         type = lib.types.functionTo diskoLib.jsonType;
-        inherit (attrs) default;
+        default = attrs.default;
         description = "Mount script";
       };
 

--- a/types/default.nix
+++ b/types/default.nix
@@ -325,7 +325,7 @@ rec {
   };
 
   subTypes = lib.mapAttrs (_: diskoLib.mkSubType) {
-    nodev =  ./nodev.nix;
+    nodev = ./nodev.nix;
     btrfs = ./btrfs.nix;
     btrfs_subvol = ./btrfs_subvol.nix;
     filesystem = ./filesystem.nix;
@@ -341,6 +341,6 @@ rec {
     mdadm = ./mdadm.nix;
     mdraid = ./mdraid.nix;
     luks = ./luks.nix;
-    disk =  ./disk.nix;
+    disk = ./disk.nix;
   };
 }

--- a/types/lvm_vg.nix
+++ b/types/lvm_vg.nix
@@ -42,7 +42,7 @@
             vgchange -a y
             ${lib.concatMapStrings (x: x.dev or "") (lib.attrValues lvMounts)}
           '';
-          inherit (lvMounts) fs;
+          fs = lvMounts.fs;
         };
     };
     _config = lib.mkOption {

--- a/types/nodev.nix
+++ b/types/nodev.nix
@@ -54,8 +54,8 @@
       readOnly = true;
       default = [{
         fileSystems.${config.mountpoint} = {
-          inherit (config) device;
-          inherit (config) fsType;
+          device = config.device;
+          fsType = config.fsType;
           options = config.mountOptions;
         };
       }];

--- a/types/swap.nix
+++ b/types/swap.nix
@@ -40,7 +40,7 @@
       default = dev: [{
         swapDevices = [{
           device = dev;
-          inherit (config) randomEncryption;
+          randomEncryption = config.randomEncryption;
         }];
       }];
       description = "NixOS configuration";


### PR DESCRIPTION
Following on from #143 

## Add config for `statix`

> We can merge them with the inherits and can try to configure the formater later

Awesome! Thanks for being flexible. I can be on the fence about the inherit fixes myself. Looks easy to disable, but it appears there are two variants to that check;

```
W03 manual_inherit
W04 manual_inherit_from
```

<details>
<summary>(Probably uninteresting detail on the difference here)</summary>


The former being cases like;

```
[W03] Warning: Assignment instead of inherit
    ╭─[<stdin>:18:3]
    │
 18 │   types = types;
    ·   ───────┬──────
    ·          ╰──────── This assignment is better written with inherit
────╯
```

the latter being;

```
[W04] Warning: Assignment instead of inherit from
    ╭─[./types/lvm_vg.nix:45:11]
    │
 45 │           fs = lvMounts.fs;
    ·           ────────┬────────
    ·                   ╰────────── This assignment is better written with inherit
────╯
```

obviously the difference being whether the `inherit` would require `inherit (foo) bar` rather than just `inherit bar`.

Just because the choice is there, I did wonder if W04 is the more objectionable of the two with;

```nix
inherit (eval) options;
```

seeming a bit of a pain compared to;

```nix
options = eval.options
```

when compared to `types = types;` ➡ `inherit types;` and while I enjoyed the brief diversionary contemplation, I'm not sure whether I'm that invested one way or the other!

</details>

So I've just disabled both for now.

## Add `nix fmt` support in flake

Just noticed this exists and figured it might be better to codify stuff in the flake, so it's easy to track and run.

As a side effect I realised that previously I hadn't applied `nixpkgs-fmt` recursively (I should have used `**/*.nix` not `**.nix`) so `nix fmt` does a better job than the manual command.

## Re-apply normalisation

As I said, I missed some files with original run of `nixpkgs-fmt` so this normalises those. Also undid then reapplied the `statix fix` with the new config which should remove the undesired addition of `inherit`. 