### PR TITLE
tests: add test names

### DIFF
--- a/tests/bcachefs.nix
+++ b/tests/bcachefs.nix
@@ -5,6 +5,7 @@ let
   linux-bcachefs = pkgs.callPackage ../linux-testing-bcachefs.nix { };
 in
 makeDiskoTest {
+  name = "bcachefs";
   disko-config = ../example/bcachefs.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/boot-raid1.nix
+++ b/tests/boot-raid1.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "boot-raid1";
   disko-config = ../example/boot-raid1.nix;
   extraTestScript = ''
     machine.succeed("test -b /dev/md/boot");

--- a/tests/btrfs-subvolumes.nix
+++ b/tests/btrfs-subvolumes.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "btrfs-subvolumes";
   disko-config = ../example/btrfs-subvolumes.nix;
   extraTestScript = ''
     machine.succeed("test -e /test");

--- a/tests/cli.nix
+++ b/tests/cli.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "cli";
   disko-config = ../example/complex.nix;
   extraConfig = {
     fileSystems."/zfs_legacy_fs".options = [ "nofail" ]; # TODO find out why we need this!

--- a/tests/complex.nix
+++ b/tests/complex.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "complex";
   disko-config = ../example/complex.nix;
   extraConfig = {
     fileSystems."/zfs_legacy_fs".options = [ "nofail" ]; # TODO find out why we need this!

--- a/tests/gpt-bios-compat.nix
+++ b/tests/gpt-bios-compat.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "gpt-bios-compat";
   disko-config = ../example/gpt-bios-compat.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/hybrid-tmpfs-on-root.nix
+++ b/tests/hybrid-tmpfs-on-root.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "hybrid-tmpfs-on-root";
   disko-config = ../example/hybrid-tmpfs-on-root.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/hybrid.nix
+++ b/tests/hybrid.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "hybrid";
   disko-config = ../example/hybrid.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -5,7 +5,8 @@
 }:
 {
   makeDiskoTest =
-    { disko-config
+    { name
+    , disko-config
     , extraTestScript ? ""
     , bootCommands ? ""
     , extraConfig ? { }
@@ -70,7 +71,7 @@
       }).config.system.build.toplevel;
     in
     makeTest' {
-      name = "disko";
+      name = "disko-${name}";
 
       inherit enableOCR;
       nodes.machine = { config, pkgs, modulesPath, ... }: {

--- a/tests/luks-lvm.nix
+++ b/tests/luks-lvm.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "luks-lvm";
   disko-config = ../example/luks-lvm.nix;
   extraTestScript = ''
     machine.succeed("cryptsetup isLuks /dev/vda2");

--- a/tests/lvm-raid.nix
+++ b/tests/lvm-raid.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "lvm-raid";
   disko-config = ../example/lvm-raid.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /home");

--- a/tests/mdadm.nix
+++ b/tests/mdadm.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "mdadm";
   disko-config = ../example/mdadm.nix;
   extraTestScript = ''
     machine.succeed("test -b /dev/md/raid1");

--- a/tests/module.nix
+++ b/tests/module.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "module";
   disko-config = ../example/complex.nix;
   extraConfig = {
     fileSystems."/zfs_legacy_fs".options = [ "nofail" ]; # TODO find out why we need this!

--- a/tests/multi-device-no-deps.nix
+++ b/tests/multi-device-no-deps.nix
@@ -3,6 +3,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "multi-device-no-deps";
   disko-config = ../example/multi-device-no-deps.nix;
   testBoot = false;
   extraTestScript = ''

--- a/tests/negative-size.nix
+++ b/tests/negative-size.nix
@@ -3,6 +3,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "negative-size";
   disko-config = ../example/negative-size.nix;
   testBoot = false;
   extraTestScript = ''

--- a/tests/simple-efi.nix
+++ b/tests/simple-efi.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "simple-efi";
   disko-config = ../example/simple-efi.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/swap.nix
+++ b/tests/swap.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "swap";
   disko-config = ../example/swap.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/tmpfs.nix
+++ b/tests/tmpfs.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "tmpfs";
   disko-config = ../example/tmpfs.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/with-lib.nix
+++ b/tests/with-lib.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "with-lib";
   disko-config = ../example/with-lib.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");

--- a/tests/zfs-over-legacy.nix
+++ b/tests/zfs-over-legacy.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "zfs-over-legacy";
   disko-config = ../example/zfs-over-legacy.nix;
   extraTestScript = ''
     machine.succeed("test -e /zfs_fs");

--- a/tests/zfs.nix
+++ b/tests/zfs.nix
@@ -2,6 +2,7 @@
 , makeDiskoTest ? (pkgs.callPackage ./lib.nix { }).makeDiskoTest
 }:
 makeDiskoTest {
+  name = "zfs";
   disko-config = ../example/zfs.nix;
   extraConfig = {
     fileSystems."/zfs_legacy_fs".options = [ "nofail" ]; # TODO find out why we need this!


### PR DESCRIPTION
Having to piece together which `vm-test-run-disko> [...]` is which test when running `nix flake check -vL` was getting a little annyoing 😄

So this makes them all have distinct names so when they are interleaved in Nix output, it's possible to tell them apart

Let me know if having names on the disko tests is undesired for any reason