### PR TITLE
tests: adjust wait_for_text calls to work for systemd-initrd or old stage-1

### DIFF
--- a/tests/cli.nix
+++ b/tests/cli.nix
@@ -19,7 +19,7 @@ makeDiskoTest {
   '';
   enableOCR = true;
   bootCommands = ''
-    machine.wait_for_text("Passphrase for")
+    machine.wait_for_text("[Pp]assphrase for")
     machine.send_chars("secretsecret\n")
   '';
   extraConfig = {

--- a/tests/complex.nix
+++ b/tests/complex.nix
@@ -18,7 +18,7 @@ makeDiskoTest {
   '';
   enableOCR = true;
   bootCommands = ''
-    machine.wait_for_text("Passphrase for")
+    machine.wait_for_text("[Pp]assphrase for")
     machine.send_chars("secretsecret\n")
   '';
   extraConfig = {

--- a/tests/luks-lvm.nix
+++ b/tests/luks-lvm.nix
@@ -9,7 +9,7 @@ makeDiskoTest {
   '';
   enableOCR = true;
   bootCommands = ''
-    machine.wait_for_text("Passphrase for")
+    machine.wait_for_text("[Pp]assphrase for")
     machine.send_chars("secretsecret\n")
   '';
 }

--- a/tests/module.nix
+++ b/tests/module.nix
@@ -19,7 +19,7 @@ makeDiskoTest {
   '';
   enableOCR = true;
   bootCommands = ''
-    machine.wait_for_text("Passphrase for")
+    machine.wait_for_text("[Pp]assphrase for")
     machine.send_chars("secretsecret\n")
   '';
   extraConfig = {

--- a/tests/zfs.nix
+++ b/tests/zfs.nix
@@ -12,7 +12,7 @@ makeDiskoTest {
   '';
   enableOCR = true;
   bootCommands = ''
-    machine.wait_for_text("passphrase for")
+    machine.wait_for_text("(?:passphrase|key) for")
     machine.send_chars("secretsecret\n")
   '';
   extraTestScript = ''


### PR DESCRIPTION
Related to #108, this fixes `wait_for_text` calls to match against both the old stage-1 and systemd-initrd console prompts for passphrases

It'll be needed later if we intend to enable systemd-initrd on some tests or do a test matrix with it both on+off