### PR TITLE
lvm_vg: allow putting unmounted disks into lvm

### DIFF
--- a/types/lvm_vg.nix
+++ b/types/lvm_vg.nix
@@ -44,7 +44,7 @@
             vgchange -a y
             ${lib.concatMapStrings (x: x.dev or "") (lib.attrValues lvMounts)}
           '';
-          fs = lvMounts.fs;
+          fs = lvMounts.fs or { };
         };
     };
     _config = lib.mkOption {


### PR DESCRIPTION
the error was

```
error: attribute 'fs' missing

       at /nix/store/1s8vxpcqla8hcch7dn3h1lg0b5hf515p-disko/share/disko/types/lvm_vg.nix:47:16:

           46|           '';
           47|           fs = lvMounts.fs;
             |                ^
           48|         };
(use '--show-trace' to show detailed location information)

```