### PR TITLE
fix(cli): pass --root-mountpoint value as string

### DIFF
--- a/disko
+++ b/disko
@@ -72,7 +72,7 @@ while [[ $# -gt 0 ]]; do
       dry_run=y
       ;;
     --root-mountpoint)
-      nix_args+=(--arg rootMountPoint "$2")
+      nix_args+=(--argstr rootMountPoint "$2")
       shift
       ;;
     --no-deps)


### PR DESCRIPTION
With `--arg`, the value is a Nix expression, so for `rootMountPoint` to be a string. its value must be passed with quotes:

```
--root-mountpoint '"/path/to/mnt"'
```

`--argstr` ensures the value can only be a string. `--root-mountpoint /path/to/mnt` will work.

If expecting a Nix expression adds some desired flexibility, I would update the usage to clarify it.