### PR TITLE
luks: add key file size & offset parameters

### DIFF
--- a/types/luks.nix
+++ b/types/luks.nix
@@ -95,6 +95,9 @@
         [
           # TODO do we need this always in initrd and only there?
           { boot.initrd.luks.devices.${config.name}.device = dev; }
+          (lib.optional (config.keyFile != null) { boot.initrd.luks.devices.${config.name} = {inherit (config) keyFile; };})
+          (lib.optional (config.keyFileSize != null) { boot.initrd.luks.devices.${config.name} = {inherit (config) keyFileSize; };})
+          (lib.optional (config.keyFileOffset != null) { boot.initrd.luks.devices.${config.name} = { inherit (config) keyFileOffset; };})
         ] ++ (lib.optional (config.content != null) (config.content._config "/dev/mapper/${config.name}"));
       description = "NixOS configuration";
     };


### PR DESCRIPTION
Pretty self-explanatory: this adds config options for LUKS `--keyfile-size` and `--keyfile-offset` parameters, so that someone can configure a specific segment of the key file to be used when creating the container.

Manually tested that this works & verified that it's selecting a chunk at the specified offset from the key file.

i should go and add a test for this, since it's not too much work, but i figured i would open the PR to see if there are any objections to this.