### PR TITLE
Add `enableCryptodisk` to quickstart guide

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -127,6 +127,8 @@ the existing lines about `systemd-boot`:
    boot.loader.grub.version = 2;
    boot.loader.grub.efiSupport = true;
    boot.loader.grub.efiInstallAsRemovable = true;
+   # uncomment below line if you use luks
+   #boot.loader.grub.enableCryptodisk = true; 
 # ...
 ```
 


### PR DESCRIPTION
I was surprised to see some errors after following the quickstart guide. 
It turned out that it was because of that one missing setting. 

I think that it would be good to mention it somewhere, not sure if the suggested place it the best option. 