### PR TITLE
zpool: don't mount created datasets directly; and fix encrypted import

### DIFF
--- a/types/zfs_fs.nix
+++ b/types/zfs_fs.nix
@@ -38,8 +38,11 @@
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
+      # -u prevents mounting newly created datasets, which is
+      # important to prevent accidental shadowing of mount points
+      # since (create order != mount order)
       default = { zpool }: ''
-        zfs create ${zpool}/${config.name} \
+        zfs create -u ${zpool}/${config.name} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)}
       '';
     };

--- a/types/zpool.nix
+++ b/types/zpool.nix
@@ -82,7 +82,7 @@
         {
           dev = ''
             zpool list '${config.name}' >/dev/null 2>/dev/null || \
-              zpool import -R ${config.mountRoot} '${config.name}'
+              zpool import -l -R ${config.mountRoot} '${config.name}'
             ${lib.concatMapStrings (x: x.dev or "") (lib.attrValues datasetMounts)}
           '';
           fs = (datasetMounts.fs or {}) // lib.optionalAttrs (config.mountpoint != null) {


### PR DESCRIPTION
This is necessary to support non-legacy mounts, since the creation order and the required mounting order can be different in order to not shadow any datasets (see #141).

Adding `-l` to the import statement is also necessary to allow encrypted datasets to be mounted later using disko-mount.