### PR TITLE
Don't set fileSystems by default

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -26,7 +26,7 @@ in
         should be false on an installer image etc.
       '';
       type = lib.types.bool;
-      default = true;
+      default = false;
     };
     checkScripts = lib.mkOption {
       description = ''


### PR DESCRIPTION
This generates errors without a real source:

```
       error: The option `fileSystems."/boot".device' has conflicting definition values:
       - In `/nix/store/6lyq928bzw0px9j4ylzi4ywsqrad5y6n-source/flake.nix': "/dev/sda1"
       - In `/nix/store/hdwjnpkahaqpkl1qgqx7g8ksg22xy4ra-source/hosts/glotzbert/hardware-configuration.nix': "/dev/disk/by-uuid/D1E3-1422"
```
and getting the UUIDs before formatting is tricky.