### PR TITLE
luks: add initrdUnlock option to luks type

### DIFF
--- a/types/luks.nix
+++ b/types/luks.nix
@@ -16,6 +16,11 @@
       description = "Path to the key for encryption";
       example = "/tmp/disk.key";
     };
+    initrdUnlock = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to add a boot.initrd.luks.devices entry for the specified disk.";
+    };
     extraFormatArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -64,10 +69,13 @@
       internal = true;
       readOnly = true;
       default = dev:
-        [
-          # TODO do we need this always in initrd and only there?
-          { boot.initrd.luks.devices.${config.name}.device = dev; }
-        ] ++ (lib.optional (config.content != null) (config.content._config "/dev/mapper/${config.name}"));
+        [ ]
+        # If initrdUnlock is true, then add a device entry to the initrd.luks.devices config.
+        ++ (lib.optional (config.initrdUnlock)
+          [
+            { boot.initrd.luks.devices.${config.name}.device = dev; }
+          ])
+        ++ (lib.optional (config.content != null) (config.content._config "/dev/mapper/${config.name}"));
       description = "NixOS configuration";
     };
     _pkgs = lib.mkOption {

--- a/types/luks.nix
+++ b/types/luks.nix
@@ -68,13 +68,9 @@
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
-      default = dev:
-        [ ]
+      default = dev: [ ]
         # If initrdUnlock is true, then add a device entry to the initrd.luks.devices config.
-        ++ (lib.optional (config.initrdUnlock)
-          [
-            { boot.initrd.luks.devices.${config.name}.device = dev; }
-          ])
+        ++ (lib.optional (config.initrdUnlock) [{ boot.initrd.luks.devices.${config.name}.device = dev; }])
         ++ (lib.optional (config.content != null) (config.content._config "/dev/mapper/${config.name}"));
       description = "NixOS configuration";
     };

--- a/types/luks.nix
+++ b/types/luks.nix
@@ -70,7 +70,7 @@
       readOnly = true;
       default = dev: [ ]
         # If initrdUnlock is true, then add a device entry to the initrd.luks.devices config.
-        ++ (lib.optional (config.initrdUnlock) [{ boot.initrd.luks.devices.${config.name}.device = dev; }])
+        ++ (lib.optional config.initrdUnlock [{ boot.initrd.luks.devices.${config.name}.device = dev; }])
         ++ (lib.optional (config.content != null) (config.content._config "/dev/mapper/${config.name}"));
       description = "NixOS configuration";
     };


### PR DESCRIPTION
I don't know whether this is a desired feature, so I've opened this PR mostly to stimulate a discussion. I'm happy to change the option name, or even just maintain a simple fork if this is undesirable.

Related to #192. Quoting my particular use case from that issue:

> I have a setup where I have a root disk that is just plain btrfs on a smaller SSD. I then have a data drive that is larger, and LUKS encrypted.
>
> Because Disko automatically adds an initrd.luks.devices entry, I'm prompted for a passphrase on every boot. In reality, I don't need that drive to be unlocked at the initrd phase, and normally just have an /etc/crypttab file that specifies a key file. I'd like to be able to specify an encrypted drive that doesn't end up requiring unlocking during the initrd part of the boot.

This PR introduces a new `configureInitrd` option to `luks` partitions, which when set explicitly to `false` prevents disko from modifying the initrd configuration, and therefore stops the system from trying to unlock the disk at early boot time.

This means that for non boot-critical drives, they can be lazily unlocked with a crypttab or other means later in the boot process.
