### PR TITLE
Fix a potential error in the ZFS example

### DIFF
--- a/example/zfs.nix
+++ b/example/zfs.nix
@@ -41,7 +41,7 @@
           partitions = [
             {
               name = "zfs";
-              start = "128MiB";
+              start = "0";
               end = "100%";
               content = {
                 type = "zfs";


### PR DESCRIPTION
As far as I can tell, the example was wrong because it was copy/pasted from the first disk definition which also includes a `/boot` partition. Consuming the entire second disk is perfectly reasonable.