### PR TITLE
types: add support for /dev/xvd[a-z] style disks

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -51,8 +51,8 @@ let
        => "/dev/disk/by-id/xxx-part2"
     */
     deviceNumbering = dev: index:
-      if match "/dev/[vs]d.+" dev != null then
-        dev + toString index  # /dev/{s,v}da style
+      if match "/dev/([vs]|(xv)d).+" dev != null then
+        dev + toString index  # /dev/{s,v,xv}da style
       else if match "/dev/(disk|zvol)/.+" dev != null then
         "${dev}-part${toString index}" # /dev/disk/by-id/xxx style, also used by zfs's zvolumes
       else if match "/dev/((nvme|mmcblk).+|md/.*[[:digit:]])" dev != null then


### PR DESCRIPTION
This style is used in the xen hypervisor
```sh
$ lsblk
lsblk
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
xvda    202:0    0   40G  0 disk
├─xvda1 202:1    0  200M  0 part /boot
└─xvda2 202:2    0 39.8G  0 part /nix/store
                                 /
```