### PR TITLE
introduce new table_gpt type

### DIFF
--- a/example/simple-efi.nix
+++ b/example/simple-efi.nix
@@ -5,33 +5,27 @@
         device = builtins.elemAt disks 0;
         type = "disk";
         content = {
-          type = "table";
-          format = "gpt";
-          partitions = [
-            {
-              name = "ESP";
-              start = "1MiB";
-              end = "100MiB";
-              bootable = true;
+          type = "table_gpt";
+          partitions = {
+            ESP = {
+              type = "EF00";
+              start = "1M";
+              end = "+100M";
               content = {
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
               };
-            }
-            {
-              name = "root";
-              start = "100MiB";
-              end = "100%";
-              part-type = "primary";
-              bootable = true;
+            };
+            root = {
+              end = "-0";
               content = {
                 type = "filesystem";
                 format = "ext4";
                 mountpoint = "/";
               };
-            }
-          ];
+            };
+          };
         };
       };
     };

--- a/example/simple-efi.nix
+++ b/example/simple-efi.nix
@@ -5,7 +5,7 @@
         device = builtins.elemAt disks 0;
         type = "disk";
         content = {
-          type = "table_gpt";
+          type = "gpt";
           partitions = {
             ESP = {
               type = "EF00";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -31,7 +31,7 @@ let
     # option for valid contents of devices
     deviceType = extraArgs: lib.mkOption {
       type = lib.types.nullOr (diskoLib.subType {
-        types = { inherit (diskoLib.types) table table_gpt btrfs filesystem zfs mdraid luks lvm_pv swap; };
+        types = { inherit (diskoLib.types) table gpt btrfs filesystem zfs mdraid luks lvm_pv swap; };
         inherit extraArgs;
       });
       default = null;

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -1,4 +1,4 @@
-{ config, options, diskoLib, lib, rootMountPoint, ... }:
+{ config, options, diskoLib, lib, rootMountPoint, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -54,6 +54,10 @@
       type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
       default = null;
       description = "A path to mount the BTRFS filesystem to.";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/disk.nix
+++ b/lib/types/disk.nix
@@ -16,7 +16,7 @@
       type = diskoLib.optionTypes.absolute-pathname; # TODO check if subpath of /dev ? - No! eg: /.swapfile
       description = "Device path";
     };
-    content = diskoLib.deviceType;
+    content = diskoLib.deviceType { parent = config; };
     _meta = lib.mkOption {
       internal = true;
       readOnly = true;

--- a/lib/types/filesystem.nix
+++ b/lib/types/filesystem.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, rootMountPoint, ... }:
+{ config, options, lib, diskoLib, rootMountPoint, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -24,6 +24,10 @@
     format = lib.mkOption {
       type = lib.types.str;
       description = "Format of the filesystem";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -1,0 +1,120 @@
+{ config, options, lib, diskoLib, parent, ... }@args:
+{
+  options = {
+    type = lib.mkOption {
+      type = lib.types.enum [ "gpt" ];
+      internal = true;
+      description = "Partition table";
+    };
+    partitions = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule ({ name, ... }@partition: {
+        options = {
+          type = lib.mkOption {
+            type = lib.types.strMatching "[A-Fa-f0-9]{4}";
+            default = "8300";
+            description = "Filesystem type to use, run sgdisk -L to see what is available";
+          };
+          priority = lib.mkOption {
+            type = lib.types.int;
+            default = 1000;
+            description = "Priority of the partition, higher priority partitions are created first";
+          };
+          name = lib.mkOption {
+            type = lib.types.str;
+            description = "Name of the partition";
+            default = name;
+          };
+          label = lib.mkOption {
+            type = lib.types.str;
+            default = "${config._parent.type}-${config._parent.name}-${partition.name}";
+          };
+          start = lib.mkOption {
+            type = lib.types.str;
+            default = "0";
+            description = "Start of the partition, in sgdisk format, use 0 for next available range";
+          };
+          end = lib.mkOption {
+            type = lib.types.str;
+            description = ''
+              End of the partition, in sgdisk format.
+              Use + for relative sizes from the partitons start
+              or - for relative sizes from the disks end
+            '';
+          };
+          content = diskoLib.partitionType { parent = config; };
+        };
+      }));
+      default = [ ];
+      description = "Attrs of partitions to add to the partition table";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
+    _meta = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo diskoLib.jsonType;
+      default = dev:
+        lib.foldr lib.recursiveUpdate { } (lib.imap
+          (index: partition:
+            lib.optionalAttrs (partition.content != null) (partition.content._meta dev)
+          )
+          (lib.attrValues config.partitions));
+      description = "Metadata";
+    };
+    _create = diskoLib.mkCreateOption {
+      inherit config options;
+      default = { dev }: ''
+        ${lib.concatStrings (lib.imap (index: partition: ''
+          sgdisk \
+            --new=${toString index}:${partition.start}:${partition.end} \
+            --change-name=${toString index}:${partition.label} \
+            --typecode=${toString index}:${partition.type} \
+            ${dev}
+          # ensure /dev/disk/by-path/..-partN exists before continuing
+          udevadm trigger --subsystem-match=block; udevadm settle
+          ${lib.optionalString (partition.content != null) (partition.content._create { dev = "/dev/disk/by-partlabel/${partition.label}"; })}
+        '') (lib.attrValues config.partitions))}
+      '';
+    };
+    _mount = diskoLib.mkMountOption {
+      inherit config options;
+      default = { dev }:
+        let
+          partMounts = lib.foldr lib.recursiveUpdate { } (lib.imap
+            (index: partition:
+              lib.optionalAttrs (partition.content != null) (partition.content._mount { dev = "/dev/disk/by-partlabel/${partition.label}"; })
+            )
+            (lib.attrValues config.partitions));
+        in
+        {
+          dev = partMounts.dev or "";
+          fs = partMounts.fs or { };
+        };
+    };
+    _config = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      default = dev:
+        lib.imap
+          (index: partition:
+            lib.optional (partition.content != null) (partition.content._config "/dev/disk/by-partlabel/${partition.label}")
+          )
+          (lib.attrValues config.partitions);
+      description = "NixOS configuration";
+    };
+    _pkgs = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo (lib.types.listOf lib.types.package);
+      default = pkgs:
+        [ pkgs.gptfdisk pkgs.systemdMinimal ] ++ lib.flatten (map
+          (partition:
+            lib.optional (partition.content != null) (partition.content._pkgs pkgs)
+          )
+          (lib.attrValues config.partitions));
+      description = "Packages";
+    };
+  };
+}

--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, ... }:
+{ config, options, lib, diskoLib, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -33,7 +33,11 @@
       description = "Extra arguments to pass to `cryptsetup luksOpen` when opening";
       example = [ "--allow-discards" ];
     };
-    content = diskoLib.deviceType;
+    content = diskoLib.deviceType { parent = config; };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
     _meta = lib.mkOption {
       internal = true;
       readOnly = true;

--- a/lib/types/lvm_pv.nix
+++ b/lib/types/lvm_pv.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, ... }:
+{ config, options, lib, diskoLib, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -9,6 +9,10 @@
     vg = lib.mkOption {
       type = lib.types.str;
       description = "Volume group";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/lvm_vg.nix
+++ b/lib/types/lvm_vg.nix
@@ -33,7 +33,7 @@
             default = [ ];
             description = "Extra arguments";
           };
-          content = diskoLib.partitionType;
+          content = diskoLib.partitionType { parent = config; };
         };
       }));
       default = { };

--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -22,7 +22,7 @@
       default = "default";
       description = "Metadata";
     };
-    content = diskoLib.deviceType;
+    content = diskoLib.deviceType { parent = config; };
     _meta = lib.mkOption {
       internal = true;
       readOnly = true;

--- a/lib/types/mdraid.nix
+++ b/lib/types/mdraid.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, ... }:
+{ config, options, lib, diskoLib, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -10,6 +10,10 @@
     name = lib.mkOption {
       type = lib.types.str;
       description = "Name";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -1,4 +1,4 @@
-{ diskoLib, config, options, lib, ... }:
+{ diskoLib, config, options, lib, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -10,6 +10,10 @@
       type = lib.types.bool;
       default = false;
       description = "Whether to randomly encrypt the swap";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, ... }:
+{ config, options, lib, diskoLib, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -48,11 +48,15 @@
             default = false;
             description = "Whether to make the partition bootable";
           };
-          content = diskoLib.partitionType;
+          content = diskoLib.partitionType { parent = config; };
         };
       }));
       default = [ ];
       description = "List of partitions to add to the partition table";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/zfs.nix
+++ b/lib/types/zfs.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, ... }:
+{ config, options, lib, diskoLib, parent, ... }:
 {
   options = {
     type = lib.mkOption {
@@ -9,6 +9,10 @@
     pool = lib.mkOption {
       type = lib.types.str;
       description = "Name of the ZFS pool";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
     };
     _meta = lib.mkOption {
       internal = true;

--- a/lib/types/zfs_fs.nix
+++ b/lib/types/zfs_fs.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, rootMountPoint, ... }:
+{ config, options, lib, diskoLib, rootMountPoint, parent, ... }:
 {
   options = {
     name = lib.mkOption {
@@ -29,6 +29,10 @@
       description = "Path to mount the dataset to";
     };
 
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
     _meta = lib.mkOption {
       internal = true;
       readOnly = true;

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, diskoLib, ... }:
+{ config, options, lib, diskoLib, parent, ... }:
 {
   options = {
     name = lib.mkOption {
@@ -30,8 +30,12 @@
       description = "Size of the dataset";
     };
 
-    content = diskoLib.partitionType;
+    content = diskoLib.partitionType { parent = config; };
 
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
     _meta = lib.mkOption {
       internal = true;
       readOnly = true;

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -49,7 +49,10 @@
       '';
     };
     datasets = lib.mkOption {
-      type = lib.types.attrsOf (diskoLib.subType { inherit (diskoLib.types) zfs_fs zfs_volume; });
+      type = lib.types.attrsOf (diskoLib.subType {
+        types = { inherit (diskoLib.types) zfs_fs zfs_volume; };
+        extraArgs.parent = config;
+      });
       description = "List of datasets to define";
     };
     _meta = lib.mkOption {

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -14,7 +14,7 @@
     , efi ? true
     , enableOCR ? false
     , postDisko ? ""
-    , testMode ? "direct" # can be one of direct module cli
+    , testMode ? "module" # can be one of direct module cli
     , testBoot ? true # if we actually want to test booting or just create/mount
     }:
     let
@@ -65,10 +65,12 @@
           efiInstallAsRemovable = efi;
         };
       };
-      installedTopLevel = (eval-config {
+      installed-system-eval = eval-config {
         modules = [ installed-system ];
         inherit (pkgs) system;
-      }).config.system.build.toplevel;
+      };
+
+      installedTopLevel = installed-system-eval.config.system.build.toplevel;
     in
     makeTest' {
       name = "disko-${name}";
@@ -111,6 +113,9 @@
         };
 
         virtualisation.emptyDiskImages = builtins.genList (_: 4096) num-disks;
+
+        # useful for debugging via repl
+        system.build.systemToInstall = installed-system-eval;
       };
 
       testScript = { nodes, ... }: ''

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -145,7 +145,7 @@
           machine.succeed("${nodes.machine.system.build.formatScript}")
           machine.succeed("${nodes.machine.system.build.mountScript}")
           machine.succeed("${nodes.machine.system.build.mountScript}") # verify that the command is idempotent
-          machine.succeed("${nodes.machine.system.build.disko}") # verify that we can destroy and recreate again
+          machine.succeed("${nodes.machine.system.build.diskoScript}") # verify that we can destroy and recreate again
         ''}
         ${lib.optionalString (testMode == "cli") ''
           # TODO use the disko cli here


### PR DESCRIPTION
we also add a new way to reference the parent node in the subtypes, this will be used in the future to simplify the code a bit (since we can pass device directly into an option instead of passing it to the _create, _mount and _config functions. this will also turn these into strings instead of functions, preparing the way for partial applications.

Also this new type uses partlabels instead of deviceNames, getting rid of the deviceNumbering logic we use in the other tables. This would also grant the ability to read the device during runtime from the environment. 