### PR TITLE
feat(swap): add resumeDevice option which sets boot.resumeDevice

### DIFF
--- a/example/swap.nix
+++ b/example/swap.nix
@@ -38,6 +38,7 @@
               content = {
                 type = "swap";
                 randomEncryption = true;
+                resumeDevice = true;  # resume from hiberation from this device
               };
             }
           ];

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -56,7 +56,7 @@
           device = config.device;
           randomEncryption = config.randomEncryption;
         }];
-        boot.resumeDevice = lib.mkIf config.resumeDevice dev;
+        boot.resumeDevice = lib.mkIf config.resumeDevice config.device;
       }];
       description = "NixOS configuration";
     };

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -16,6 +16,11 @@
       default = false;
       description = "Whether to randomly encrypt the swap";
     };
+    resumeDevice = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to use this as a boot.resumeDevice";
+    };
     _parent = lib.mkOption {
       internal = true;
       default = parent;
@@ -51,6 +56,7 @@
           device = config.device;
           randomEncryption = config.randomEncryption;
         }];
+        boot.resumeDevice = lib.mkIf config.resumeDevice dev;
       }];
       description = "NixOS configuration";
     };


### PR DESCRIPTION
Quickly drafted idea, this adds a boolean option `resumeDevice` for swap, which sets `boot.resumeDevice` to `dev` when set to true.

Related issue: #277