### PR TITLE
flake: expose the module as nixosModules.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
     {
+      nixosModules.default = self.nixosModules.disko; # convention
       nixosModules.disko = import ./module.nix;
       lib = import ./. {
         inherit (nixpkgs) lib;


### PR DESCRIPTION
If there is only one module that is getting exported, the convention is
to use that "default" value as the name.
