### PR TITLE
disko cli: fix error about impurity with nix

### DIFF
--- a/disko
+++ b/disko
@@ -116,8 +116,10 @@ else
   abort "disko config must be an existing file or flake must be set"
 fi
 
+# The "--impure" is still pure, as the path is withing the nix store.
 script=$(nix-build "${libexec_dir}"/cli.nix \
   --no-out-link \
+  --impure \
   --argstr mode "$mode" \
   "${nix_args[@]}"
 )


### PR DESCRIPTION
The script is generated by calling `nix-build` on the `cli.nix` file. This fails on systems, which have the nix option pure_eval set, as nix refuses to evaluate an untracked file. This would normally be impure, but in this case the file is supplied in the same nix store path, i.e. it's not referencing foreign files. Thus adding the `--impure` argument should leave the nix call in fact still pure.