### PR TITLE
Luks add additionalKeyFiles option

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -32,6 +32,7 @@
                 type = "luks";
                 name = "crypted1";
                 settings.keyFile = "/tmp/secret.key";
+                additionalKeyFiles = ["/tmp/additionalSecret.key"];
                 extraFormatArgs = [
                   "--iter-time 1" # unsecure but fast for tests
                 ];

--- a/example/luks-lvm.nix
+++ b/example/luks-lvm.nix
@@ -33,6 +33,7 @@
                 # if you want to use the key for interactive login be sure there is no trailing newline
                 # for example use `echo -n "password" > /tmp/secret.key`
                 settings.keyFile = "/tmp/secret.key";
+                additionalKeyFiles = ["/tmp/additionalSecret.key"];
                 content = {
                   type = "lvm_pv";
                   vg = "pool";

--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -44,6 +44,12 @@ in
         };
       '';
     };
+    additionalKeyFiles = lib.mkOption {
+      type = lib.types.listOf diskoLib.optionTypes.absolute-pathname;
+      default = [];
+      description = "Path to additional key files for encryption";
+      example = ["/tmp/disk2.key"];
+    };
     initrdUnlock = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -82,6 +88,7 @@ in
         cryptsetup luksOpen ${config.device} ${config.name} \
           ${toString config.extraOpenArgs} \
           ${keyFileArgs}
+        ${toString (lib.lists.forEach config.additionalKeyFiles (x: "cryptsetup luksAddKey ${config.device} ${x} ${keyFileArgs}"))}
         ${lib.optionalString (config.content != null) config.content._create}
       '';
     };

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -135,6 +135,7 @@
 
         machine.start()
         machine.succeed("echo -n 'secretsecret' > /tmp/secret.key")
+        machine.succeed("echo -n 'additionalSecret' > /tmp/additionalSecret.key")
         ${lib.optionalString (testMode == "direct") ''
           machine.succeed("${tsp-create}")
           machine.succeed("${tsp-mount}")


### PR DESCRIPTION
Currently disko allow only a single keyfile. I add an additional option to specify more key files. 

Hint: Separate option of the first key has the benefit to get the possible of passphrase + keyfile for an luks volume. 