### PR TITLE
feat(luks): Add settings submodule

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -31,9 +31,9 @@
               content = {
                 type = "luks";
                 name = "crypted1";
-                keyFile = "/tmp/secret.key";
+                settings.keyFile = "/tmp/secret.key";
                 extraFormatArgs = [
-                  "--iter-time 1"
+                  "--iter-time 1" # unsecure but fast for tests
                 ];
                 content = {
                   type = "lvm_pv";
@@ -56,9 +56,9 @@
               content = {
                 type = "luks";
                 name = "crypted2";
-                keyFile = "/tmp/secret.key";
+                settings.keyFile = "/tmp/secret.key";
                 extraFormatArgs = [
-                  "--iter-time 1"
+                  "--iter-time 1" # unsecure but fast for tests
                 ];
                 content = {
                   type = "lvm_pv";

--- a/example/luks-lvm.nix
+++ b/example/luks-lvm.nix
@@ -32,7 +32,7 @@
                 extraOpenArgs = [ "--allow-discards" ];
                 # if you want to use the key for interactive login be sure there is no trailing newline
                 # for example use `echo -n "password" > /tmp/secret.key`
-                keyFile = "/tmp/secret.key";
+                settings.keyFile = "/tmp/secret.key";
                 content = {
                   type = "lvm_pv";
                   vg = "pool";


### PR DESCRIPTION
This mirrors the NixOS boot.initrd.luks.devices.<name>.keyFileOffset and boot.initrd.luks.devices.<name>.keyFileSize options.