### PR TITLE
feat(btrfs): support unmounted subvolumes

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,3 +1,56 @@
+# 2023-07-09 121df48
+
+Changes:
+ - BTRFS subvolumes are mounted if and only their `mountpoint` is set.
+
+Especially, if you have specific mount options for a subvolume (through `mountOptions`), make sure to set `mountpoint` otherwise the subvolume will not be mounted.
+
+This change allows more flexibility when using BTRFS, giving access to its volume management functionality.
+
+It allows layouts as the following:
+```nix
+content = {
+  type = "btrfs";
+  # BTRFS partition is not mounted as it doesn't set a mountpoint explicitly
+  subvolumes = {
+    # This subvolume will not be mounted
+    "SYSTEM" = { };
+    # mounted as "/"
+    "SYSTEM/rootfs" = {
+      mountpoint = "/";
+    };
+    # mounted as "/nix"
+    "SYSTEM/nix" = {
+      mountOptions = [ "compress=zstd" "noatime" ];
+      mountpoint = "/nix";
+    };
+    # This subvolume will not be mounted
+    "DATA" = { };
+    # mounted as "/home"
+    "DATA/home" = {
+      mountOptions = [ "compress=zstd" ];
+      mountpoint = "/home";
+    };
+    # mounted as "/var/www"
+    "DATA/www" = {
+      mountpoint = "/var/www";
+    };
+  };
+};
+```
+corresponding to the following BTRFS layout:
+```
+BTRFS partition # not mounted
+ |
+ |-SYSTEM       # not mounted
+ |  |-rootfs    # mounted as "/"
+ |  |-nix       # mounted as "/nix"
+ |
+ |-DATA         # not mounted
+    |-home      # mounted as "/home"
+    |-www       # mounted as "/var/www"
+```
+
 # 2023-04-07 7d70009
 
 Changes:

--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -24,18 +24,26 @@
               content = {
                 type = "btrfs";
                 extraArgs = [ "-f" ]; # Override existing partition
+                # Subvolumes must set a mountpoint in order to be mounted,
+                # unless their parent is mounted
                 subvolumes = {
                   # Subvolume name is different from mountpoint
                   "/rootfs" = {
                     mountpoint = "/";
                   };
-                  # Mountpoints inferred from subvolume name
+                  # Subvolume name is the same as the mountpoint
                   "/home" = {
                     mountOptions = [ "compress=zstd" ];
+                    mountpoint = "/home";
                   };
+                  # Sub(sub)volume doesn't need a mountpoint as its parent is mounted
+                  "/home/user" = { };
+                  # Parent is not mounted so the mountpoint must be set
                   "/nix" = {
                     mountOptions = [ "compress=zstd" "noatime" ];
+                    mountpoint = "/nix";
                   };
+                  # This subvolume will be created but not mounted
                   "/test" = { };
                 };
               };

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -91,16 +91,10 @@
         let
           subvolMounts = lib.concatMapAttrs
             (_: subvol:
-              let
-                mountpoint =
-                  if (subvol.mountpoint != null) then subvol.mountpoint
-                  else if (config.mountpoint == null) then subvol.name
-                  else null;
-              in
-              lib.optionalAttrs (mountpoint != null) {
-                ${mountpoint} = ''
-                  if ! findmnt ${config.device} "${rootMountPoint}${mountpoint}" > /dev/null 2>&1; then
-                    mount ${config.device} "${rootMountPoint}${mountpoint}" \
+              lib.optionalAttrs (subvol.mountpoint != null) {
+                ${subvol.mountpoint} = ''
+                  if ! findmnt ${config.device} "${rootMountPoint}${subvol.mountpoint}" > /dev/null 2>&1; then
+                    mount ${config.device} "${rootMountPoint}${subvol.mountpoint}" \
                     ${lib.concatMapStringsSep " " (opt: "-o ${opt}") (subvol.mountOptions ++ [ "subvol=${subvol.name}" ])} \
                     -o X-mount.mkdir
                   fi

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -91,6 +91,8 @@
         let
           subvolMounts = lib.concatMapAttrs
             (_: subvol:
+            lib.warnIf (subvol.mountOptions != (options.subvolumes.type.getSubOptions []).mountOptions.default && subvol.mountpoint == null)
+              "Subvolume ${subvol.name} has mountOptions but no mountpoint. See upgrade guide (2023-07-09 121df48)."
               lib.optionalAttrs (subvol.mountpoint != null) {
                 ${subvol.mountpoint} = ''
                   if ! findmnt ${config.device} "${rootMountPoint}${subvol.mountpoint}" > /dev/null 2>&1; then

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -123,14 +123,8 @@
       default = [
         (map
           (subvol:
-            let
-              mountpoint =
-                if (subvol.mountpoint != null) then subvol.mountpoint
-                else if (config.mountpoint == null) then subvol.name
-                else null;
-            in
-            lib.optional (mountpoint != null) {
-              fileSystems.${mountpoint} = {
+            lib.optional (subvol.mountpoint != null) {
+              fileSystems.${subvol.mountpoint} = {
                 device = config.device;
                 fsType = "btrfs";
                 options = subvol.mountOptions ++ [ "subvol=${subvol.name}" ];

--- a/tests/btrfs-subvolumes.nix
+++ b/tests/btrfs-subvolumes.nix
@@ -6,7 +6,8 @@ makeDiskoTest {
   name = "btrfs-subvolumes";
   disko-config = ../example/btrfs-subvolumes.nix;
   extraTestScript = ''
-    machine.succeed("test -e /test");
+    machine.succeed("test ! -e /test");
+    machine.succeed("test -e /home/user");
     machine.succeed("btrfs subvolume list / | grep -qs 'path test$'");
     machine.succeed("btrfs subvolume list / | grep -qs 'path nix$'");
     machine.succeed("btrfs subvolume list / | grep -qs 'path home$'");


### PR DESCRIPTION
This option allows the creation of subvolumes which won't be mounted, allowing to create more complex btrfs layouts.

This is a personal attempt to fix the issue #288, since it didn't seem to get much attention.