### PR TITLE
fix(luks): type error with keyfile size/offset

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -7,8 +7,8 @@ let
     else null;
   keyFileArgs = ''\
     ${lib.optionalString (keyFile != null) "--key-file ${keyFile}"} \
-    ${lib.optionalString (lib.hasAttr "keyFileSize" config.settings) "--keyfile-size ${config.settings.keyFileSize}"} \
-    ${lib.optionalString (lib.hasAttr "keyFileOffset" config.settings) "--keyfile-offset ${config.settings.keyFileOffset}"}
+    ${lib.optionalString (lib.hasAttr "keyFileSize" config.settings) "--keyfile-size ${builtins.toString config.settings.keyFileSize}"} \
+    ${lib.optionalString (lib.hasAttr "keyFileOffset" config.settings) "--keyfile-offset ${builtins.toString config.settings.keyFileOffset}"}
   '';
 in
 {


### PR DESCRIPTION
Using `keyFileOffset`/`keyFileSize` leads to a `cannot coerce an integer to a string` error. Since they are used to generate the `cryptsetup` command in a script as text, they need to be converted to a string.