### PR TITLE
docs(luks): add an example using keyFile options

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -58,7 +58,11 @@
               content = {
                 type = "luks";
                 name = "crypted2";
-                settings.keyFile = "/tmp/secret.key";
+                settings = {
+                  keyFile = "/tmp/secret.key";
+                  keyFileSize = 8;
+                  keyFileOffset = 2;
+                };
                 extraFormatArgs = [
                   "--iter-time 1" # unsecure but fast for tests
                 ];


### PR DESCRIPTION
This adds `keyFileOffset` and `keyFileSize` options in `example/complex.nix`. It follows the discussion in #301.

I thought that adding a new example file for these options was a lot of noise for little result. 

@Lassulus if you meant something else with "a new test", please put me on tracks, as I quickly checked the `tests` folder and couldn't think about something relevant I could add there. 