### PR TITLE
Fix msdos partition table creation

### DIFF
--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -88,7 +88,7 @@
             parted -s ${config.device} -- mkpart ${partition.name} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
           ''}
           ${lib.optionalString (config.format == "msdos") ''
-            parted -s ${config.device} -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
+            parted -s ${config.device} -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
           ''}
           # ensure /dev/disk/by-path/..-partN exists before continuing
           udevadm trigger --subsystem-match=block


### PR DESCRIPTION
In the `formatScript`, the partition fs-type was specified twice on partition creation when the msdos partition table type is used. Fix this to only be specified once.

A minimal error-reproducing configuration:
```nix
{
  disko.devices.disk.disk0 = {
    device = "/dev/mmcblk0";
    type = "disk";
    content = {
      type = "table";
      format = "msdos";
      partitions = [{
        fs-type = "fat32";
        start = "1MiB";
        end = "512MiB";
      }];
    };
  };
}
```

Produces the following format script:
```bash
#! /nix/store/hjala5j03vxhkj6rvgj8kdigm1yrw0p4-bash-5.1-p16/bin/bash
export PATH=/nix/store/2bif24ymzcfb1kdr746yxxi199wlng0w-jq-1.6-bin/bin:/nix/store/mdyd76bv92zx74k7zvihaypwycfdgz1j-parted-3.5/bin:/nix/store/ywygk5zd365clas5im16vv7zcg9nyvd2-systemd-minimal-251.7/bin:$PATH
set -efux

disko_devices_dir=$(mktemp -d)
trap 'rm -rf "$disko_devices_dir"' EXIT
mkdir -p "$disko_devices_dir"

( # disk disk0 /dev/mmcblk0   #
  device='/dev/mmcblk0'
  name='disk0'
  type='disk'
  
  ( # table  /dev/mmcblk0 msdos  #
    device='/dev/mmcblk0'
    format='msdos'
    type='table'
    
    parted -s /dev/mmcblk0 -- mklabel msdos
    
    parted -s /dev/mmcblk0 -- mkpart primary fat32 fat32 1MiB 512MiB
    
    # ensure /dev/disk/by-path/..-partN exists before continuing
    udevadm trigger --subsystem-match=block
    udevadm settle
    
    
    # ensure further operations can detect new partitions
    udevadm trigger --subsystem-match=block
    udevadm settle
    
    
    
    
  )
  
  
)
```

The fix in this PR removes the second `fat32` fs-type.