### PR TITLE
Create luks-btrfs-subvolumes.nix

### DIFF
--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -1,0 +1,60 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        type = "disk";
+        device = "/dev/vdb";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              label = "EFI";
+              name = "ESP";
+              size = "512M";
+              type = "EF00" ;
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [
+                  "defaults"
+                ];
+              };
+            };
+            luks = {
+              size = "100%";
+              content = {
+                type = "luks";
+                name = "crypted";
+                extraOpenArgs = [ "--allow-discards" ];
+                # if you want to use the key for interactive login be sure there is no trailing newline
+                # for example use `echo -n "password" > /tmp/secret.key`
+                #keyFile = "/tmp/secret.key"; # Interactive
+                settings.keyFile = "/tmp/secret.key";
+                additionalKeyFiles = ["/tmp/additionalSecret.key"];
+                content = {
+                  type = "btrfs";
+                  extraArgs = [ "-f" ];
+                  subvolumes = {
+                    "/root" = {
+                      mountpoint = "/";
+                      mountOptions = [ "compress=zstd" "noatime" ];
+                    };
+                    "/home" = {
+                      mountpoint = "/home";
+                      mountOptions = [ "compress=zstd" "noatime" ];
+                    };
+                    "/nix" = {
+                      mountpoint = "/nix";
+                      mountOptions = [ "compress=zstd" "noatime" ];
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/luks-btrfs-subvolumes.nix
+++ b/tests/luks-btrfs-subvolumes.nix
@@ -1,0 +1,13 @@
+{ pkgs ? (import <nixpkgs> { })
+, makeDiskoTest ? (pkgs.callPackage ../lib { }).testLib.makeDiskoTest
+}:
+makeDiskoTest {
+  inherit pkgs;
+  name = "luks-btrfs-subvolumes";
+  disko-config = ../example/luks-btrfs-subvolumes.nix;
+  extraTestScript = ''
+  machine.succeed("cryptsetup isLuks /dev/vda2");
+  machine.succeed("btrfs subvolume list / | grep -qs 'path nix$'");
+  machine.succeed("btrfs subvolume list / | grep -qs 'path home$'");
+  '';
+}


### PR DESCRIPTION
This adds an example for BTRFS Subvolumes inside of a LUKS container (dmcrypt).

Will allow to close #54 and closed #246. 

I hope this will be of use to the community.
