### PR TITLE
Added missing dependency to destroyScript

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -386,7 +386,8 @@ let
                 zfs
                 lvm2
                 bash
-              ])}:${lib.makeBinPath (cfg.config._packages pkgs)}:$PATH
+                jq
+              ])}:$PATH
               ${cfg.config._destroy}
             '';
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -385,7 +385,8 @@ let
                 mdadm
                 zfs
                 lvm2
-              ])}:$PATH
+                bash
+              ])}:${lib.makeBinPath (cfg.config._packages pkgs)}:$PATH
               ${cfg.config._destroy}
             '';
 


### PR DESCRIPTION
This PR adds 2 missing deps for destroyScript:
- `jq`: Unlike other scripts, destroyScript wasn't pulling in `${lib.makeBinPath (cfg.config._packages pkgs)`
- `bash`: destroyScript already uses bash for its shebang but it looks like wipefs also need bash in the PATH