### PR TITLE
Rename keyFile to passwordFile and dedeprecate

### DIFF
--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -29,7 +29,7 @@
                 extraOpenArgs = [ "--allow-discards" ];
                 # if you want to use the key for interactive login be sure there is no trailing newline
                 # for example use `echo -n "password" > /tmp/secret.key`
-                #keyFile = "/tmp/secret.key"; # Interactive
+                #passwordFile = "/tmp/secret.key"; # Interactive
                 settings.keyFile = "/tmp/secret.key";
                 additionalKeyFiles = [ "/tmp/additionalSecret.key" ];
                 content = {

--- a/example/luks-interactive-login.nix
+++ b/example/luks-interactive-login.nix
@@ -1,0 +1,38 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        type = "disk";
+        device = "/dev/vdb";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "100M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            luks = {
+              size = "100%";
+              content = {
+                type = "luks";
+                name = "crypted";
+                extraOpenArgs = [ "--allow-discards" ];
+                passwordFile = "/tmp/secret.key";
+                content = {
+                  type = "filesystem";
+                  format = "ext4";
+                  mountpoint = "/";
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -3,8 +3,10 @@ let
   keyFile =
     if lib.hasAttr "keyFile" config.settings
     then config.settings.keyFile
+    else if config.passwordFile != null
+    then config.passwordFile
     else if config.keyFile != null
-    then lib.warn "The option `keyFile` is deprecated. See the `settings` option." config.keyFile
+    then lib.warn "The option `keyFile` is deprecated. Use passwordFile instead" config.keyFile
     else null;
   keyFileArgs = ''\
     ${lib.optionalString (keyFile != null) "--key-file ${keyFile}"} \
@@ -31,7 +33,13 @@ in
     keyFile = lib.mkOption {
       type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
       default = null;
-      description = "Path to the key for encryption";
+      description = "Path to the key for encryption (Renamed to passwordFile)";
+      example = "/tmp/disk.key";
+    };
+    passwordFile = lib.mkOption {
+      type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
+      default = null;
+      description = "Path to the file which contains the password for initial encryption. Make sure it doesn't contain a trailing newline";
       example = "/tmp/disk.key";
     };
     settings = lib.mkOption {

--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -4,9 +4,12 @@ let
     if lib.hasAttr "keyFile" config.settings
     then config.settings.keyFile
     else if config.passwordFile != null
-    then config.passwordFile
+    then ''<(echo -n "$(cat ${config.passwordFile})")''
     else if config.keyFile != null
-    then lib.warn "The option `keyFile` is deprecated. Use passwordFile instead" config.keyFile
+    then lib.warn
+      ("The option `keyFile` is deprecated."
+      + "Use passwordFile instead if you want to use interactive login or settings.keyFile if you want to use key file login")
+      config.keyFile
     else null;
   keyFileArgs = ''\
     ${lib.optionalString (keyFile != null) "--key-file ${keyFile}"} \
@@ -33,13 +36,13 @@ in
     keyFile = lib.mkOption {
       type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
       default = null;
-      description = "Path to the key for encryption (Renamed to passwordFile)";
+      description = "DEPRECATED use passwordFile or settings.keyFile. Path to the key for encryption";
       example = "/tmp/disk.key";
     };
     passwordFile = lib.mkOption {
       type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
       default = null;
-      description = "Path to the file which contains the password for initial encryption. Make sure it doesn't contain a trailing newline";
+      description = "Path to the file which contains the password for initial encryption";
       example = "/tmp/disk.key";
     };
     settings = lib.mkOption {

--- a/tests/luks-interactive-login.nix
+++ b/tests/luks-interactive-login.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "luks-interactive-login";
+  disko-config = ../example/luks-interactive-login.nix;
+  extraTestScript = ''
+    machine.succeed("cryptsetup isLuks /dev/vda2");
+  '';
+}

--- a/tests/luks-interactive-login.nix
+++ b/tests/luks-interactive-login.nix
@@ -8,4 +8,8 @@ diskoLib.testLib.makeDiskoTest {
   extraTestScript = ''
     machine.succeed("cryptsetup isLuks /dev/vda2");
   '';
+  bootCommands = ''
+    machine.wait_for_console_text("vda")
+    machine.send_console("secretsecret\n")
+  '';
 }


### PR DESCRIPTION
I run the checks with the following patch, because otherwise it wasn't working (see https://github.com/nix-community/disko/issues/321)

```diff
diff --git a/flake.nix b/flake.nix
index 561a847..3d9ca74 100644
--- a/flake.nix
+++ b/flake.nix
@@ -28,14 +28,14 @@
         in
         {
           disko = pkgs.callPackage ./package.nix { };
-          disko-doc = pkgs.callPackage ./doc.nix { };
+          # disko-doc = pkgs.callPackage ./doc.nix { };
           default = self.packages.${system}.disko;
         });
       # TODO: disable bios-related tests on aarch64...
       # Run checks: nix flake check -L
-      checks = forAllSystems (system:
+      checks.x86_64-linux =
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
           nixosTests = import ./tests {
             inherit pkgs;
             makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
@@ -47,7 +47,7 @@
             touch $out
           '';
         in
-        nixosTests // { inherit shellcheck; });
+        nixosTests // { inherit shellcheck; };
       formatter = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
```