### PR TITLE
mdadm: insert grub module for mdraid

### DIFF
--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -65,6 +65,9 @@
           } else {
             boot.initrd.services.swraid.enable = true;
           })
+          {
+            boot.loader.grub.extraConfig = lib.optionalString (config.content._mount == "/boot" && config.metadata != "1") "insmod mdraid1x";
+          }
         ] ++
         lib.optional (config.content != null) config.content._config;
       description = "NixOS configuration";


### PR DESCRIPTION
the condition is not perfect yet. I think one could also have no /boot and just / and grub might be also installed at a different mountpoint than /boot?