### PR TITLE
tests: Add failing test to demonstrate issues with whitespace in part…

### DIFF
--- a/example/gpt-name-with-whitespace.nix
+++ b/example/gpt-name-with-whitespace.nix
@@ -1,0 +1,41 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        device = "/dev/disk/by-id/some-disk-id";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              type = "EF00";
+              size = "100M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            "name with spaces" = {
+              type = "EF00";
+              size = "100M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/name_with_spaces";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/example/legacy-table-with-whitespace.nix
+++ b/example/legacy-table-with-whitespace.nix
@@ -1,0 +1,50 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        device = "/dev/sda";
+        type = "disk";
+        content = {
+          type = "table";
+          format = "gpt";
+          partitions = [
+            {
+              name = "ESP";
+              start = "1MiB";
+              end = "100MiB";
+              bootable = true;
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            }
+            {
+              name = "name with spaces";
+              start = "1MiB";
+              end = "100MiB";
+              bootable = true;
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/name_with_spaces";
+              };
+            }
+            {
+              name = "root";
+              start = "100MiB";
+              end = "100%";
+              part-type = "primary";
+              bootable = true;
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/tests/gpt-name-with-whitespace.nix
+++ b/tests/gpt-name-with-whitespace.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "gpt-name-with-whitespace";
+  disko-config = ../example/gpt-name-with-whitespace.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+    machine.succeed("mountpoint /name_with_spaces");
+  '';
+}

--- a/tests/legacy-table-with-whitespace.nix
+++ b/tests/legacy-table-with-whitespace.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "legacy-table-with-whitespace";
+  disko-config = ../example/legacy-table-with-whitespace.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+    machine.succeed("mountpoint /name_with_spaces");
+  '';
+}


### PR DESCRIPTION
… names

Reproduces #130.

For new style table the generated script has a few problems for example;

```sh
    sgdisk \
      --new=2:0:+100M \
      --change-name=2:disk-vdb-name with spaces \
      --typecode=2:EF00 \
      /dev/vdb
```

and

```sh
mkfs.vfat \
         \
        /dev/disk/by-partlabel/disk-vdb-name with spaces
```

Legacy table style generates slightly different problems e.g.;

```sh
parted -s /dev/vdb -- mkpart name with spaces  1MiB 100MiB
```