### PR TITLE
Fix problem with missing part. labels.

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -44,6 +44,7 @@ let
     ${pkgs.systemdMinimal}/lib/systemd/systemd-udevd --daemon
     udevadm trigger --action=add
     udevadm settle
+    partprobe
 
     # populate nix db, so nixos-install doesn't complain
     export NIX_STATE_DIR=$TMPDIR/state

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -107,6 +107,7 @@ in
           # ensure /dev/disk/by-path/..-partN exists before continuing
           udevadm trigger --subsystem-match=block
           udevadm settle
+          partprobe
           ${lib.optionalString (partition.content != null) partition.content._create}
         '') sortedPartitions)}
 

--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -44,6 +44,7 @@
           "''${disk_devices[@]}"
         udevadm trigger --subsystem-match=block
         udevadm settle
+        partprobe
         # for some reason mdadm devices spawn with an existing partition table, so we need to wipe it
         sgdisk --zap-all /dev/md/${config.name}
         ${lib.optionalString (config.content != null) config.content._create}

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -93,6 +93,7 @@
           # ensure /dev/disk/by-path/..-partN exists before continuing
           udevadm trigger --subsystem-match=block
           udevadm settle
+          partprobe
           ${lib.optionalString partition.bootable ''
             parted -s ${config.device} -- set ${toString partition._index} boot on
           ''}
@@ -102,6 +103,7 @@
           # ensure further operations can detect new partitions
           udevadm trigger --subsystem-match=block
           udevadm settle
+          partprobe
           ${lib.optionalString (partition.content != null) partition.content._create}
         '') config.partitions)}
       '';

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -52,6 +52,7 @@
           -V ${config.size}
         udevadm trigger --subsystem-match=block
         udevadm settle
+        partprobe
         ${lib.optionalString (config.content != null) config.content._create}
       '';
     };


### PR DESCRIPTION
After `sgdisk` I got:

```
Warning: The kernel is still using the old partition table.
The new table will be used at the next reboot or after you
run partprobe(8) or kpartx(8)
The operation has completed successfully.
```

And then:

```
mkswap: cannot open /dev/disk/by-partlabel/...: No such file or directory
```

This is a simple solution to this problem.