### PR TITLE
some small fixups

### DIFF
--- a/example/mdadm-raid0.nix
+++ b/example/mdadm-raid0.nix
@@ -1,0 +1,65 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        type = "disk";
+        device = "/dev/my-disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            boot = {
+              size = "1M";
+              type = "EF02"; # for grub MBR
+            };
+            mdadm = {
+              size = "100%";
+              content = {
+                type = "mdraid";
+                name = "raid0";
+              };
+            };
+          };
+        };
+      };
+      vdc = {
+        type = "disk";
+        device = "/dev/my-disk2";
+        content = {
+          type = "gpt";
+          partitions = {
+            boot = {
+              size = "1M";
+              type = "EF02"; # for grub MBR
+            };
+            mdadm = {
+              size = "100%";
+              content = {
+                type = "mdraid";
+                name = "raid0";
+              };
+            };
+          };
+        };
+      };
+    };
+    mdadm = {
+      raid0 = {
+        type = "mdadm";
+        level = 0;
+        content = {
+          type = "gpt";
+          partitions = {
+            primary = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -18,9 +18,10 @@ let
     bash
     coreutils
     gnused
+    parted # for partprobe
     systemdMinimal
     nix
-    utillinux
+    util-linux
   ];
   preVM = ''
     ${lib.concatMapStringsSep "\n" (disk: "truncate -s ${disk.imageSize} ${disk.name}.raw") (lib.attrValues nixosConfig.config.disko.devices.disk)}

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -146,7 +146,11 @@ in
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
       default = pkgs:
-        [ pkgs.gptfdisk pkgs.systemdMinimal ] ++ lib.flatten (map
+        [
+          pkgs.gptfdisk
+          pkgs.systemdMinimal
+          pkgs.parted # for partprobe
+        ] ++ lib.flatten (map
           (partition:
             lib.optional (partition.content != null) (partition.content._pkgs pkgs)
           )

--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -74,7 +74,9 @@
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: (lib.optionals (config.content != null) (config.content._pkgs pkgs));
+      default = pkgs: [
+        pkgs.parted # for partprobe
+      ] ++ (lib.optionals (config.content != null) (config.content._pkgs pkgs));
       description = "Packages";
     };
   };

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -72,7 +72,10 @@
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: [ pkgs.util-linux ] ++ lib.optionals (config.content != null) (config.content._pkgs pkgs);
+      default = pkgs: [
+        pkgs.util-linux
+        pkgs.parted # for partprobe
+      ] ++ lib.optionals (config.content != null) (config.content._pkgs pkgs);
       description = "Packages";
     };
   };

--- a/tests/mdadm-raid0.nix
+++ b/tests/mdadm-raid0.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "mdadm-raid0";
+  disko-config = ../example/mdadm-raid0.nix;
+  extraTestScript = ''
+    machine.succeed("test -b /dev/md/raid0");
+    machine.succeed("mountpoint /");
+  '';
+  efi = false;
+}


### PR DESCRIPTION
tests with nix-build were broken, so adding parted where partprobe is used fixes that
we also add a test for raid0, which failed earlier today due to not being removed by the disk-deactvate script 