### PR TITLE
Specify alignment for sgdisk.

### DIFF
--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -100,6 +100,8 @@ in
       default = ''
         ${lib.concatStrings (map (partition: ''
           sgdisk \
+            --set-alignment=2048 \
+            --align-end \
             --new=${toString partition._index}:${partition.start}:${partition.end} \
             --change-name=${toString partition._index}:${partition.label} \
             --typecode=${toString partition._index}:${partition.type} \


### PR DESCRIPTION
The following command:

`sgdisk --new=4:0:-0 /dev/xda`

will work but unless the overall disk size is aligned to 4k, the new partition will not be aligned to 4k.

`--set-alignment=2048 --align-end` aligns new partitions to 1 MiB (2048 sectors). This enables for example `--sector-size=4096` for `cryptsetup luksFormat`.