### PR TITLE
Add extra args into swap.

### DIFF
--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -11,6 +11,11 @@
       default = device;
       description = "Device";
     };
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments";
+    };
     randomEncryption = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -35,7 +40,9 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        mkswap ${config.device}
+        mkswap \
+          ${toString config.extraArgs} \
+          ${config.device}
       '';
     };
     _mount = diskoLib.mkMountOption {


### PR DESCRIPTION
The `swap` type doesn't have `extraArgs` like for example `btrfs` / `filesystem` type has. I tested it with `[ "-f" "--label=abc" ]` and it works well.