### PR TITLE
fix: unbound variables are forbidden

### DIFF
--- a/disko
+++ b/disko
@@ -23,7 +23,7 @@ Options:
 * -m, --mode mode
   set the mode, either format, mount or disko
     format: create partition tables, zpools, lvms, raids and filesystems
-    mount: mount the partition at the specified root-mountpoint (default to /mnt)
+    mount: mount the partition at the specified root-mountpoint
     disko: first unmount and destroy all filesystems on the disks we want to format, then run the create and mount mode
 * -f, --flake uri
   fetch the disko config relative to this flake's root
@@ -31,8 +31,8 @@ Options:
   pass value to nix-build. can be used to set disk-names for example
 * --argstr name value
   pass value to nix-build as string
-* --root-mountpoint /mnt
-  where to mount the device tree
+* --root-mountpoint /some/other/mnt
+  where to mount the device tree (default: /mnt)
 * --dry-run
   just show the path to the script instead of running it
 * --debug

--- a/disko
+++ b/disko
@@ -37,8 +37,6 @@ Options:
   just show the path to the script instead of running it
 * --no-deps
   avoid adding another dependency closure to an in-memory installer
-    recommended when using flake attributes variant where the flake's
-    nixpkgs and the nixpkgs version of the in-memory installer may diverge
     requires all necessary dependencies to be available in the environment
 * --debug
   run with set -x

--- a/disko
+++ b/disko
@@ -13,7 +13,9 @@ nix_args=()
 showUsage() {
   cat <<USAGE
 Usage: $0 [options] disk-config.nix
-or $0 [options] --flake github:somebody/somewhere
+or $0 [options] --flake github:somebody/somewhere#disk-config
+
+With flakes, disk-config is discovered under the .diskoConfigurations top level attribute.
 
 Options:
 

--- a/disko
+++ b/disko
@@ -35,6 +35,11 @@ Options:
   where to mount the device tree (default: /mnt)
 * --dry-run
   just show the path to the script instead of running it
+* --no-deps
+  avoid adding another dependency closure to an in-memory installer
+    recommended when using flake attributes variant where the flake's
+    nixpkgs and the nixpkgs version of the in-memory installer may diverge
+    requires all necessary dependencies to be available in the environment
 * --debug
   run with set -x
 USAGE

--- a/disko
+++ b/disko
@@ -105,7 +105,7 @@ if [[ -n "${flake+x}" ]]; then
    flake="${BASH_REMATCH[1]}"
    flakeAttr="${BASH_REMATCH[2]}"
   fi
-  if [[ -z "$flakeAttr" ]]; then
+  if [[ -z "${flakeAttr-}" ]]; then
     echo "Please specify the name of the NixOS configuration to be installed, as a URI fragment in the flake-uri."
     echo "For example, to use the output diskoConfigurations.foo from the flake.nix, append \"#foo\" to the flake-uri."
     exit 1

--- a/disko
+++ b/disko
@@ -15,7 +15,8 @@ showUsage() {
 Usage: $0 [options] disk-config.nix
 or $0 [options] --flake github:somebody/somewhere#disk-config
 
-With flakes, disk-config is discovered under the .diskoConfigurations top level attribute.
+With flakes, disk-config is discovered first under the .diskoConfigurations top level attribute
+or else from the disko module of a NixOS configuration of that name under .nixosConfigurations.
 
 Options:
 


### PR DESCRIPTION
# Context

`disko` sets `set -u`. If the user forgets to set the flake attr (e.g. because the useage string doesn't suggest so), then an unbound error is raised.

# Solution

- default to nothing if unbound
- fix the usage string
