### PR TITLE
Changing how to open LUKS.

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -114,7 +114,7 @@ in
         {
           dev = ''
             cryptsetup status ${config.name} >/dev/null 2>/dev/null ||
-              cryptsetup luksOpen ${config.device} ${config.name} \
+              cryptsetup open ${config.device} ${config.name} \
               ${keyFileArgs}
             ${lib.optionalString (config.content != null) contentMount.dev or ""}
           '';


### PR DESCRIPTION
Changing how to open encrypted partition from `luksOpen` to `open`.

`open` works same as `luksOpen` for LUKS1/2 but it is more flexible so it is possible to pass `--type=plain`.

I tested it with both LUKS2 and plain encrypted partitions in a single file.