### PR TITLE
fix: avoid external probing effects from other devices

### DIFF
--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -107,7 +107,7 @@ in
             --typecode=${toString partition._index}:${partition.type} \
             ${config.device}
           # ensure /dev/disk/by-path/..-partN exists before continuing
-          partprobe
+          partprobe ${config.device}
           udevadm trigger --subsystem-match=block
           udevadm settle
           ${lib.optionalString (partition.content != null) partition.content._create}

--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -42,7 +42,7 @@
           --force \
           --homehost=any \
           "''${disk_devices[@]}"
-        partprobe
+        partprobe /dev/md/${config.name}
         udevadm trigger --subsystem-match=block
         udevadm settle
         # for some reason mdadm devices spawn with an existing partition table, so we need to wipe it

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -91,7 +91,7 @@
             parted -s ${config.device} -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
           ''}
           # ensure /dev/disk/by-path/..-partN exists before continuing
-          partprobe
+          partprobe ${config.device}
           udevadm trigger --subsystem-match=block
           udevadm settle
           ${lib.optionalString partition.bootable ''
@@ -101,7 +101,7 @@
             parted -s ${config.device} -- set ${toString partition._index} ${flag} on
           '') partition.flags}
           # ensure further operations can detect new partitions
-          partprobe
+          partprobe ${config.device}
           udevadm trigger --subsystem-match=block
           udevadm settle
           ${lib.optionalString (partition.content != null) partition.content._create}

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -50,7 +50,7 @@
         zfs create ${config._parent.name}/${config.name} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
           -V ${config.size}
-        partprobe
+        partprobe /dev/zvol/${config._parent.name}/${config.name}
         udevadm trigger --subsystem-match=block
         udevadm settle
         ${lib.optionalString (config.content != null) config.content._create}


### PR DESCRIPTION
# Context

partprobe without `[DEVICE]` probes all _devices_ and thus those devices can have external effects.

One such external effect is, for example, the following error that had been observed when using a usb live stick device (potentially damaged or otherwise not entirely appropriatly set up).

```console
Error: Partition(s) 1 on /dev/sda have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.
```

# Proposed Solution

- Strictly specify the `[DEVICE]` in scope where possible

# Review Note
```console
disko on  fix/external-effects-on-partprobe took 2m55s
❯ rg 'partprobe'
lib/make-disk-image.nix
21:    parted # for partprobe
46:    partprobe

lib/types/mdadm.nix
45:        partprobe /dev/md/${config.name}
78:        pkgs.parted # for partprobe

lib/types/table.nix
94:          partprobe ${config.device}
104:          partprobe ${config.device}

lib/types/gpt.nix
110:          partprobe ${config.device}
154:          pkgs.parted # for partprobe

lib/types/zfs_volume.nix
53:        partprobe /dev/zvol/${config._parent.name}/${config.name}
77:        pkgs.parted # for partprobe
```

`lib/make-disk-image.nix` seemed ambiguous, but I understand it's also "just" for VM tests and hence a controlled environment (i.e. no external effects).
