### PR TITLE
make-disk-image: allow secrets-pre-install but after partioning

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -32,7 +32,7 @@ let
     ${lib.concatMapStringsSep "\n" (disk: "cp ${disk.name}.raw \"$out\"/${disk.name}.raw") (lib.attrValues nixosConfig.config.disko.devices.disk)}
     ${extraPostVM}
   '';
-  builder = ''
+  partitioner = ''
     # running udev, stolen from stage-1.sh
     echo "running udev..."
     ln -sfn /proc/self/fd /dev/fd
@@ -54,6 +54,8 @@ let
     }}/registration
 
     ${systemToInstall.config.system.build.diskoScript}
+  '';
+  installer = ''
     ${systemToInstall.config.system.build.nixos-install}/bin/nixos-install --system ${systemToInstall.config.system.build.toplevel} --keep-going --no-channel-copy -v --no-root-password --option binary-caches ""
   '';
   QEMU_OPTS = lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report") (lib.attrValues nixosConfig.config.disko.devices.disk);
@@ -65,7 +67,7 @@ in
       inherit preVM QEMU_OPTS;
       memSize = 1024;
     }
-    builder);
+    (partitioner + installer));
   impure = diskoLib.writeCheckedBash { inherit checked pkgs; } name ''
     set -efu
     export PATH=${lib.makeBinPath dependencies}
@@ -128,7 +130,7 @@ in
         cp -r "$src" "$dst"
       done
       set -f
-      ${builder}
+      ${partitioner}
       set +f
       for src in /tmp/xchg/copy_after_disko/*; do
         [ -e "$src" ] || continue
@@ -136,6 +138,7 @@ in
         mkdir -p "$(dirname "$dst")"
         cp -r "$src" "$dst"
       done
+      ${installer}
     ''}
     export QEMU_OPTS=${lib.escapeShellArg "${QEMU_OPTS} -m 1024"}
     ${pkgs.bash}/bin/sh -e ${pkgs.vmTools.vmRunCommand pkgs.vmTools.qemuCommandLinux}


### PR DESCRIPTION
This small change allows to have secrets the nixos config might depend upon, for example you could now do something like this: 
```bash
sudo ./result \
 --pre-format-files /tmp/luks.key /tmp/secret.key \
 --post-format-files /etc/secureboot/files.db /etc/secureboot/files.db \
 --post-format-files /etc/secureboot/GUID /etc/secureboot/GUID \
 --post-format-files /etc/secureboot/keys/db/db.key /etc/secureboot/keys/db/db.key \
 --post-format-files /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key \
 --post-format-files /etc/ssh/ssh_host_ed25519_key.pub /etc/ssh/ssh_host_ed25519_key.pub \
 --post-format-files /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_rsa_key \
 --post-format-files /etc/ssh/ssh_host_rsa_key.pub /etc/ssh/ssh_host_rsa_key.pub \
 --post-format-files /etc/secureboot/keys/db/db.pem /etc/secureboot/keys/db/db.pem \
 --post-format-files /etc/secureboot/keys/KEK/KEK.key /etc/secureboot/keys/KEK/KEK.key \
 --post-format-files /etc/secureboot/keys/KEK/KEK.pem /etc/secureboot/keys/KEK/KEK.pem \
 --post-format-files /etc/secureboot/keys/PK/PK.key /etc/secureboot/keys/PK/PK.key \
 --post-format-files /etc/secureboot/keys/PK/PK.pem /etc/secureboot/keys/PK/PK.pem
```
And then the installer can use the data to do stuff like activate secureboot or load and decrypt secrets with a tool like sops-nix.
I actually build a image just like that and `dd` it on to a usb drive and booted and secureboot with lanzaboote and sops for secrets both just worked.


I encountered a few other problems during these steps that might be more or less easily fixable. 

One of them is that every file copied keeps it permissions exactly the same which is fine, but the ownership changes to `root:root` for every file/folder that gets created which means you cant just copy for example a users age key from `~/.config/sops/age/keys.txt` this can easily be fixed upstream by making the action in https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/update-users-groups.pl#L235-L240 recursive (just setting a few `-R`s), I might open a PR later (it's the action invoked if createHome is true which is automatically set when `users.users.<name>.isNormalUser = true;` is set).  

The next one is that the actual .raw file will be larger then the imageSize that is specified in the disko config, but the option it self is a bit meh since if the space needed by the system config is more it will just fail building and if the space is more you just end up doing a lot of unnecessary io operations where you write zeros. The solution here in my opinion has two options, one if wanting to use the image with a physical drive anyways let the user specify the device via a cli flag end pass it to the vm and install on it directly, then the disko partitioning would automatically end up using the entire drive if 100% is set in the config and you save the dd step of reading and then writing the .raw file again. And the other solution would be  to have the ImageSize as a maximum and use a dynamic image that then gets shrunken to the currently used size and  have auto resizing at system boot (which might not be possible that's just what I came up with thinking about the problem I didn't do any implementation work here).

A minor problem is that currently the output of the script build by diskoImagesScript gets cut of if the space in the terminal is not enough and the prompt gets quite wired once its done where the terminal ends up not showing characters or showing false stuff or over drawing some other stuff without it actually being there but I have no idea how to fix that. 

Another minor problem is that ctrl+c gets ignored and the only way to kill the script currently is to stop the shell session by for example closing the terminal.

And currently all the secrets in preinstalled get printed out when read in which is not that nice because then using this script in a ci is not a good idea because you would for example leak luks keys. The solution here would be to lower the verbosity by removing `set -x` or hiding it behind a `--debug` flag

And not really a problem but more like a nice to have would be a flag cli flag that will copy all the secrets into one folder with a mapping where they should be copied to and generate the diskoImagesScript. This would play nice with the mounting a actual drive into the vm option so you basically have a nice installer image that has all your secrets, config and the entire nix store needed for offline installs. 
