### PR TITLE
zfs_volume: fix /dev/zvol/ symlink race

### DIFF
--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -50,6 +50,7 @@
         zfs create ${config._parent.name}/${config.name} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
           -V ${config.size}
+        zvol_wait
         partprobe /dev/zvol/${config._parent.name}/${config.name}
         udevadm trigger --subsystem-match=block
         udevadm settle


### PR DESCRIPTION
This fixes a race condition where the partprobe command tries to read the /dev/zvol symlink, potentially before it's created