### PR TITLE
removed deprecated name file  from luks-btrfs-subvolumes example

### DIFF
--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -8,7 +8,6 @@
           type = "gpt";
           partitions = {
             ESP = {
-              label = "EFI";
               size = "512M";
               type = "EF00";
               content = {

--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -9,7 +9,6 @@
           partitions = {
             ESP = {
               label = "EFI";
-              name = "ESP";
               size = "512M";
               type = "EF00";
               content = {


### PR DESCRIPTION
I think this is the last name field in the examples.