### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,32 +59,34 @@ A simple disko configuration may look like this:
 
 ```
 { disks ? [ "/dev/vdb" ], ... }: {
- disk = {
-  vdb = {
-   device = builtins.elemAt disks 0;
-   type = "disk";
-   content = {
-    type = "gpt";
-    partitions = {
-     ESP = {
-      size = "100M";
-      content = {
-       type = "filesystem";
-       format = "vfat";
-       mountpoint = "/boot";
-      };
-     };
-     root = {
-      size = "100%";
-      content = {
-       type = "filesystem";
-       format = "ext4";
-       mountpoint = "/";
-      };
-     };
-    };
-   };
-  };
+ disko.devices = {
+  disk = {
+   vdb = {
+    device = builtins.elemAt disks 0;
+    type = "disk";
+    content = {
+     type = "gpt";
+     partitions = {
+      ESP = {
+       size = "100M";
+       content = {
+        type = "filesystem";
+        format = "vfat";
+        mountpoint = "/boot";
+       };
+      };
+      root = {
+       size = "100%";
+       content = {
+        type = "filesystem";
+        format = "ext4";
+        mountpoint = "/";
+       };
+      };
+     };
+    };
+   };
+  };
  };
 }
 ```


### PR DESCRIPTION
The minimal example was missing the wrapping `disko.devices` attributes which resulted in the following error message:

```
error: attribute 'disko' missing

       at /nix/store/1lvj5ry4y5qyis40qcch1csf8h86z8bk-disko/share/disko/default.nix:10:49:

            9|       # _file = toString input;
           10|       imports = lib.singleton { disko.devices = cfg.disko.devices; };
             |                                                 ^
           11|       options = {
       Did you mean disk?
```