### PR TITLE
luks: fix interactive mount

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -137,6 +137,13 @@ in
         {
           dev = ''
             if ! cryptsetup status ${config.name} >/dev/null 2>/dev/null; then
+              ${lib.optionalString config.askPassword ''
+                set +x
+                echo "Enter password for ${config.device}"
+                read -s password
+                export password
+                set -x
+              ''}
               cryptsetup open ${config.device} ${config.name} \
               ${keyFileArgs}
             fi


### PR DESCRIPTION
Before that it was only attempted to unlock luks with the key from `$password`, however that variable didn't exist before.

cc @Lassulus 