### PR TITLE
module: use defaultText to not depend on the configuration when building the manual

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -43,6 +43,7 @@ in
           We try to automatically detect efi based on the configured bootloader.
         '';
         type = lib.types.bool;
+        defaultText = "config.boot.loader.systemd-boot.enable || config.boot.loader.grub.efiSupport";
         default = config.boot.loader.systemd-boot.enable || config.boot.loader.grub.efiSupport;
       };
       extraChecks = lib.mkOption {


### PR DESCRIPTION
I do build my workstation with `documentation.nixos.includeAllModules` to also have private modules and external stuff in my local options' reference.

Not sure why exactly this breaks with

    error: attribute 'loader' missing

    at /nix/store/h6qicay9fgggx9nf6apdl6zkdpdp28xx-source/module.nix:46:19:

        45|         type = lib.types.bool;
        46|         default = config.boot.loader.systemd-boot.enable || config.boot.loader.grub.efiSupport;
          |                   ^
        47|       };

but using `defaultText` is the usual fix that also works here.