### PR TITLE
disk-deactivate: Remove MBR bootstrap code for disk

### DIFF
--- a/disk-deactivate/disk-deactivate
+++ b/disk-deactivate/disk-deactivate
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -efux
+#!/usr/bin/env bash
+set -efux -o pipefail
 # dependencies: bash jq util-linux lvm2 mdadm zfs
 disk=$(realpath "$1")
 

--- a/disk-deactivate/disk-deactivate.jq
+++ b/disk-deactivate/disk-deactivate.jq
@@ -26,7 +26,9 @@ def remove:
 def deactivate:
   if .type == "disk" then
     [
-      "wipefs --all -f \(.path)"
+      "wipefs --all -f \(.path)",
+      # Remove the MBR bootstrap code
+      "dd if=/dev/zero of=\(.path) bs=440 count=1"
     ]
   elif .type == "part" then
     [


### PR DESCRIPTION
Not sure if `coreutils` needs to be added to `pkgs` somewhere for `dd`, but this should work.