### PR TITLE
swap: don't mount

### DIFF
--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -47,13 +47,7 @@
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
-      default = {
-        fs.${config.device} = ''
-          if ! swapon --show | grep -q "^$(readlink -f ${config.device}) "; then
-            swapon ${config.device}
-          fi
-        '';
-      };
+      default = { };
     };
     _config = lib.mkOption {
       internal = true;


### PR DESCRIPTION
Closes #379
Swap doesn't need to be mounted at all when calling `-m mount`