### PR TITLE
luks: fix read ShellCheck warning SC2162

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -108,9 +108,9 @@ in
           set +x
           askPassword() {
             echo "Enter password for ${config.device}: "
-            read -s password
+            IFS= read -r -s password
             echo "Enter password for ${config.device} again to be safe: "
-            read -s password_check
+            IFS= read -r -s password_check
             export password
             [ "$password" = "$password_check" ]
           }
@@ -140,7 +140,7 @@ in
               ${lib.optionalString config.askPassword ''
                 set +x
                 echo "Enter password for ${config.device}"
-                read -s password
+                IFS= read -r -s password
                 export password
                 set -x
               ''}


### PR DESCRIPTION
Use `-r` to avoid mangling backslashes, use `IFS=` to not discard leading and trailing whitespace.

While trying out disko I hit warning SC2162 which caused the build script derivation to fail, because it's ShellChecked. Fix the warning with the suggested approach of combining the `-r` flag and `IFS=`.