### PR TITLE
Implement preMountHook & postMountHook

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -110,6 +110,9 @@
               mountOptions = [
                 "defaults"
               ];
+              postMountHook = ''
+                touch /mnt/ext4_on_lvm/file-from-postMountHook
+              '';
             };
           };
           raid1 = {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -238,12 +238,19 @@ let
         description = "Creation script";
       };
 
-    mkMountOption = { default, ... }@attrs:
+    mkMountOption = { config, options, default }@attrs:
       lib.mkOption {
         internal = true;
         readOnly = true;
         type = diskoLib.jsonType;
-        default = attrs.default;
+        default = lib.mapAttrsRecursive (name: value: if builtins.isString value then ''
+          (
+            ${diskoLib.indent (diskoLib.defineHookVariables { inherit options; })}
+            ${config.preMountHook}
+            ${diskoLib.indent value}
+            ${config.postMountHook}
+          )
+        '' else value) attrs.default;
         description = "Mount script";
       };
 

--- a/tests/complex.nix
+++ b/tests/complex.nix
@@ -20,6 +20,9 @@ diskoLib.testLib.makeDiskoTest {
     machine.succeed("mountpoint /zfs_legacy_fs");
     machine.succeed("mountpoint /ext4onzfs");
     machine.succeed("mountpoint /ext4_on_lvm");
+
+
+    machine.succeed("test -e /ext4_on_lvm/file-from-postMountHook");
   '';
   extraInstallerConfig = {
     boot.kernelModules = [ "dm-raid" "dm-mirror" ];


### PR DESCRIPTION
These options previously existed but had no effect. Now they are implemented. They only affect mount during disko’s filesystem creation, not during any later mounts.

Adding test case to existing “complex” example and test mostly because couldn’t think of any better place to put it.