### PR TITLE
bcachefs: add support for subvolumes

### DIFF
--- a/example/bcachefs-subvol.nix
+++ b/example/bcachefs-subvol.nix
@@ -1,0 +1,52 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        device = "/dev/disk/by-path/pci-0000:02:00.0-nvme-1";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              end = "500M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              name = "root";
+              end = "-0";
+              content = {
+                type = "bcachefs";
+                mountpoint = "/";
+                extraArgs = [
+                  "--compression zstd"
+                  "--background_compression zstd"
+                  "--block_size=4096" # 4kb block size.
+                  "--discard"
+                  "--label nroot"
+                ];
+                mountOptions = [ "noatime" ];
+                subvolumes = {
+                  # FYI, bcachefs does not support mount of subvolumes externally.
+                  # They must all be part of the / hierarchy
+                  # and they will be remounted automatically.
+                  "/home" = {
+                    mountpoint = "/home";
+                    # There's no mount options on each subvolume.
+                  };
+                  "/nix" = {
+                    mountpoint = "/nix";
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
-        "owner": "NixOS",
+        "lastModified": 1700144402,
+        "narHash": "sha256-canGMRB0mVoVCfK0oqg/XI5PYFFc31B+gWdz+quf3N8=",
+        "owner": "RaitoBezarius",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "75daf9a06568e97701092828a0570755b905f96f",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "owner": "RaitoBezarius",
+        "ref": "bcachefs-tools",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   # FIXME: in future we don't want lock here to give precedence to a USB live-installer's registry,
   # but garnix currently does not allow this.
   #inputs.nixpkgs.url = "nixpkgs";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:RaitoBezarius/nixpkgs/bcachefs-tools";
 
   outputs = { self, nixpkgs, ... }:
     let

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -35,7 +35,7 @@ let
     # option for valid contents of partitions (basically like devices, but without tables)
     partitionType = extraArgs: lib.mkOption {
       type = lib.types.nullOr (diskoLib.subType {
-        types = { inherit (diskoLib.types) btrfs filesystem zfs mdraid luks lvm_pv swap; };
+        types = { inherit (diskoLib.types) bcachefs btrfs filesystem zfs mdraid luks lvm_pv swap; };
         inherit extraArgs;
       });
       default = null;
@@ -45,7 +45,7 @@ let
     # option for valid contents of devices
     deviceType = extraArgs: lib.mkOption {
       type = lib.types.nullOr (diskoLib.subType {
-        types = { inherit (diskoLib.types) table gpt btrfs filesystem zfs mdraid luks lvm_pv swap; };
+        types = { inherit (diskoLib.types) table gpt bcachefs btrfs filesystem zfs mdraid luks lvm_pv swap; };
         inherit extraArgs;
       });
       default = null;

--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -1,0 +1,124 @@
+{ config, options, diskoLib, lib, rootMountPoint, parent, device, ... }:
+{
+  options = {
+    type = lib.mkOption {
+      type = lib.types.enum [ "bcachefs" ];
+      internal = true;
+      description = "Type";
+    };
+    device = lib.mkOption {
+      type = lib.types.str;
+      default = device;
+      description = "Device to use";
+    };
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments";
+    };
+    mountOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "defaults" ];
+      description = "A list of options to pass to mount.";
+    };
+    subvolumes = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule ({ config, ... }: {
+        options = {
+          name = lib.mkOption {
+            type = lib.types.str;
+            default = config._module.args.name;
+            description = "Name of the Bcachefs subvolume.";
+          };
+          type = lib.mkOption {
+            type = lib.types.enum [ "bcachefs_subvol" ];
+            default = "bcachefs_subvol";
+            internal = true;
+            description = "Type";
+          };
+          extraArgs = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = "Extra arguments";
+          };
+          mountpoint = lib.mkOption {
+            type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
+            default = null;
+            description = "Location to mount the subvolume to.";
+          };
+        };
+      }));
+      default = { };
+      description = "Subvolumes to define for Bcachefs.";
+    };
+    mountpoint = lib.mkOption {
+      type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
+      default = null;
+      description = "A path to mount the Bcachefs filesystem to.";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
+    _meta = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo diskoLib.jsonType;
+      default = _dev: { };
+      description = "Metadata";
+    };
+    _create = diskoLib.mkCreateOption {
+      inherit config options;
+      default = ''
+        modprobe bcachefs
+        mkfs.bcachefs ${toString config.extraArgs} ${config.device}
+        grep bcachefs /proc/filesystems
+        ${lib.concatMapStrings (subvol: ''
+          (
+            MNTPOINT=$(mktemp -d)
+            mount ${config.device} "$MNTPOINT"
+            trap 'umount $MNTPOINT; rm -rf $MNTPOINT' EXIT
+            echo "creating subvol ${subvol.name}"
+            bcachefs subvolume create "$MNTPOINT"/${subvol.name} ${toString subvol.extraArgs}
+          )
+        '') (lib.attrValues config.subvolumes)}
+      '';
+    };
+    _mount = diskoLib.mkMountOption {
+      inherit config options;
+      default =
+        {
+          fs = lib.optionalAttrs (config.mountpoint != null) {
+            ${config.mountpoint} = ''
+              if ! findmnt ${config.device} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
+                mount ${config.device} "${rootMountPoint}${config.mountpoint}" \
+                ${lib.concatMapStringsSep " " (opt: "-o ${opt}") config.mountOptions} \
+                -o X-mount.mkdir
+              fi
+            '';
+          };
+        };
+    };
+    _config = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      default = [
+       (lib.optional (config.mountpoint != null) {
+          fileSystems.${config.mountpoint} = {
+            device = config.device;
+            fsType = "bcachefs";
+            options = config.mountOptions;
+          };
+        })
+      ];
+      description = "NixOS configuration";
+    };
+    _pkgs = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo (lib.types.listOf lib.types.package);
+      default = pkgs:
+        [ pkgs.bcachefs-tools pkgs.coreutils ];
+      description = "Packages";
+    };
+  };
+}

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -25,7 +25,7 @@
             description = "Partition type";
           };
           fs-type = lib.mkOption {
-            type = lib.types.nullOr (lib.types.enum [ "btrfs" "ext2" "ext3" "ext4" "fat16" "fat32" "hfs" "hfs+" "linux-swap" "ntfs" "reiserfs" "udf" "xfs" ]);
+            type = lib.types.nullOr (lib.types.enum [ "bcachefs" "btrfs" "ext2" "ext3" "ext4" "fat16" "fat32" "hfs" "hfs+" "linux-swap" "ntfs" "reiserfs" "udf" "xfs" ]);
             default = null;
             description = "Filesystem type to use";
           };

--- a/tests/bcachefs-subvol.nix
+++ b/tests/bcachefs-subvol.nix
@@ -1,0 +1,37 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "bcachefs-subvol";
+  disko-config = ../example/bcachefs-subvol.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+    machine.succeed("lsblk >&2");
+    machine.succeed("ls /");
+  '';
+  # so that the installer boots with a bcachefs enabled kernel
+  extraInstallerConfig = {
+    # disable zfs so we can support latest kernel
+    nixpkgs.overlays = [
+      (_final: super: {
+        zfs = super.zfs.overrideAttrs (_: {
+          meta.platforms = [ ];
+        });
+      })
+    ];
+    boot.kernelPackages = pkgs.lib.mkForce pkgs.linuxPackages_testing;
+  };
+  extraSystemConfig = {
+    # disable zfs so we can support latest kernel
+    nixpkgs.overlays = [
+      (_final: super: {
+        zfs = super.zfs.overrideAttrs (_: {
+          meta.platforms = [ ];
+        });
+      })
+    ];
+    boot.kernelPackages = pkgs.lib.mkForce pkgs.linuxPackages_testing;
+  };
+
+}


### PR DESCRIPTION
Relies on unreleased NixOS commits.