### PR TITLE
fix: create btrfs subvolume parent directories

### DIFF
--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -126,8 +126,10 @@ in
             MNTPOINT=$(mktemp -d)
             mount ${config.device} "$MNTPOINT" -o subvol=/
             trap 'umount $MNTPOINT; rm -rf $MNTPOINT' EXIT
-            btrfs subvolume create "$MNTPOINT"/${subvol.name} ${toString subvol.extraArgs}
-            ${swapCreate "$MNTPOINT/${subvol.name}" subvol.swap}
+            SUBVOL_ABS_PATH="$MNTPOINT/${subvol.name}"
+            mkdir -p "$(dirname "$SUBVOL_ABS_PATH")"
+            btrfs subvolume create "$SUBVOL_ABS_PATH" ${toString subvol.extraArgs}
+            ${swapCreate "$SUBVOL_ABS_PATH" subvol.swap}
           )
         '') (lib.attrValues config.subvolumes)}
       '';


### PR DESCRIPTION
Fixes #409

Note: Because existing directories can't be converted to subvolumes directly, this implementation assumes hierarchical subvolume creation order (e.g., `/subvol1` is created before `/subvol1/subvol2`).