### PR TITLE
make-disk-image: make memSize configurable per disk

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -65,7 +65,7 @@ in
     {
       buildInputs = dependencies;
       inherit preVM postVM QEMU_OPTS;
-      memSize = 1024;
+      memSize = nixosConfig.config.disko.memSize;
     }
     (partitioner + installer));
   impure = diskoLib.writeCheckedBash { inherit checked pkgs; } name ''

--- a/module.nix
+++ b/module.nix
@@ -10,6 +10,13 @@ let
 in
 {
   options.disko = {
+    memSize = lib.mkOption {
+      type = lib.types.int;
+      description = ''
+        size of the memory passed to runInLinuxVM, in megabytes
+      '';
+      default = 1024;
+    };
     devices = lib.mkOption {
       type = diskoLib.toplevel;
       default = { };


### PR DESCRIPTION
Sometimes the VM builder can run out of memory and fail to allocate memory when installing the system toplevel, this PR allows this to be adjusted by setting `disko.memSize`