### PR TITLE
make-disk-image: inherit kernel from nixosConfiguration

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -7,6 +7,11 @@
 , checked ? false
 }:
 let
+  vmTools = pkgs.vmTools.override {
+    rootModules = ["9p" "9pnet_virtio" "virtio_pci" "virtio_blk"] ++ nixosConfig.config.disko.extraRootModules;
+    kernel = pkgs.aggregateModules
+    (with nixosConfig.config.boot.kernelPackages; [ kernel ]);
+  };
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig nixosConfig.config diskoLib.testLib.devices;
   systemToInstall = nixosConfig.extendModules {
     modules = [{
@@ -61,7 +66,7 @@ let
   QEMU_OPTS = lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report") (lib.attrValues nixosConfig.config.disko.devices.disk);
 in
 {
-  pure = pkgs.vmTools.runInLinuxVM (pkgs.runCommand name
+  pure = vmTools.runInLinuxVM (pkgs.runCommand name
     {
       buildInputs = dependencies;
       inherit preVM postVM QEMU_OPTS;
@@ -160,7 +165,7 @@ in
     QEMU_OPTS+=" -m $build_memory"
     export QEMU_OPTS
 
-    ${pkgs.bash}/bin/sh -e ${pkgs.vmTools.vmRunCommand pkgs.vmTools.qemuCommandLinux}
+    ${pkgs.bash}/bin/sh -e ${vmTools.vmRunCommand vmTools.qemuCommandLinux}
     cd /
   '';
 }

--- a/module.nix
+++ b/module.nix
@@ -10,6 +10,13 @@ let
 in
 {
   options.disko = {
+    extraRootModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str ;
+      description = ''
+        extra modules to pass to the vmTools.runCommand invocation in the make-disk-image.nix builder
+      '';
+      default = [];
+    };
     memSize = lib.mkOption {
       type = lib.types.int;
       description = ''


### PR DESCRIPTION
`tests/bcachefs.nix` only works because bcachefs is baked into the kernel, without this PR, disko is not using the same kernel as the nixosConfiguration it is building an image for, which leads to edge cases, such as being able to create a bcachefs but not mount it.

In my testing, I observed that my nixosConfiguration was on kernel 6.7-rc5, whereas Disko's  `make-disk-image.nix` reported kernel 6.1 from `uname -a`, this PR synchronizes everything so that this will never happen.

This kind of thing happened in Nixpkgs with `make-single-disk-zfs-image.nix`, with the same solution
https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/make-single-disk-zfs-image.nix#L224-L228

I've also added an `extraRootModules` to disko's toplevel which allows setting `disko.extraRootModules = [ "zram" ]` for example, in order to load zram in the disk builder like this:

```nix
...
                preCreateHook = ''
                  echo 0 > /sys/module/zswap/parameters/enabled
                  zramctl /dev/zram0 --algorithm zstd --size 32G
                  mkswap -U clear /dev/zram0
                  swapon --priority 100 /dev/zram0
                '';
...
```

This reduces the amount of ram required for the `nixos-install`, as well as the overhead of loading `extraRootModules` if any are provided.