### PR TITLE
lib/types/gpt.nix: default = [] -> default = {}

### DIFF
--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -76,7 +76,7 @@ in
           };
         };
       }));
-      default = [ ];
+      default = {};
       description = "Attrs of partitions to add to the partition table";
     };
     _parent = lib.mkOption {


### PR DESCRIPTION
This must have accidentally creeped in during a refactor