### PR TITLE
make-disk-image: allow extra dependencies to be passed into image builder

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -27,7 +27,7 @@ let
     systemdMinimal
     nix
     util-linux
-  ];
+  ] ++ nixosConfig.config.disko.extraDependencies;
   preVM = ''
     ${lib.concatMapStringsSep "\n" (disk: "truncate -s ${disk.imageSize} ${disk.name}.raw") (lib.attrValues nixosConfig.config.disko.devices.disk)}
   '';

--- a/module.nix
+++ b/module.nix
@@ -29,6 +29,13 @@ in
       default = { };
       description = "The devices to set up";
     };
+    extraDependencies = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      description = ''
+        list of extra packages to make available in the make-disk-image.nix VM builder, an example might be f2fs-tools
+      '';
+      default = [];
+    };
     rootMountPoint = lib.mkOption {
       type = lib.types.str;
       default = "/mnt";


### PR DESCRIPTION
Without this, tools like `f2fs-tools` providing `mkfs.f2fs` for a disko config making an f2fs filesystem won't be possible to pass into the `vmTools` invocation.