### PR TITLE
zpool: fix default dataset getting shadowed

### DIFF
--- a/example/non-root-zfs.nix
+++ b/example/non-root-zfs.nix
@@ -1,0 +1,79 @@
+{
+  disko.devices = {
+    disk = {
+      x = {
+        type = "disk";
+        device = "/dev/sdx";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "64M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+      y = {
+        type = "disk";
+        device = "/dev/sdy";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "storage";
+              };
+            };
+          };
+        };
+      };
+      z = {
+        type = "disk";
+        device = "/dev/sdz";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "storage";
+              };
+            };
+          };
+        };
+      };
+    };
+    zpool = {
+      storage = {
+        type = "zpool";
+        mode = "mirror";
+        mountpoint = "/storage";
+
+        datasets = {
+          dataset = {
+            type = "zfs_fs";
+            mountpoint = "/storage/dataset";
+          };
+        };
+      };
+    };
+  };
+}
+

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -67,6 +67,9 @@
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
           "''${zfs_devices[@]}"
+        ${lib.optionalString ((config.rootFsOptions.mountpoint or "") != "none") ''
+          zfs unmount ${config.name}
+        ''}
         ${lib.concatMapStrings (dataset: dataset._create) (lib.attrValues config.datasets)}
       '';
     };

--- a/tests/non-root-zfs.nix
+++ b/tests/non-root-zfs.nix
@@ -1,0 +1,26 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "non-root-zfs";
+  disko-config = ../example/non-root-zfs.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  postDisko = ''
+    machine.succeed("mountpoint /mnt/storage")
+    machine.succeed("mountpoint /mnt/storage/dataset")
+
+    filesystem = machine.execute("stat --file-system --format=%T /mnt/storage")[1].rstrip()
+    print(f"/mnt/storage {filesystem=}")
+    assert filesystem == "zfs", "/mnt/storage is not ZFS"
+  '';
+  extraTestScript = ''
+    machine.succeed("mountpoint /storage")
+    machine.succeed("mountpoint /storage/dataset")
+
+    filesystem = machine.execute("stat --file-system --format=%T /storage")[1].rstrip()
+    print(f"/mnt/storage {filesystem=}")
+    assert filesystem == "zfs", "/storage is not ZFS"
+  '';
+}


### PR DESCRIPTION
If the zpool's root dataset is not the rootfs and gets mounted on creation, the actual rootfs will get mounted later and shadow the
current mountpoint.

Running `zfs unmount` is the easiest way to unmount the zpool's root dataset on creation without messing up the value of the `mountpoint` setting.

The first commit is a regression test that ensures that the default dataset doesn't get shadowed, which fails without the second commit.