### PR TITLE
 tests: support overriding disko config

### DIFF
--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -25,7 +25,7 @@
                 type = "luks";
                 name = "crypted";
                 # disable settings.keyFile if you want to use interactive password entry
-                #passwordFile = "/tmp/secret.key"; # Interactive
+                # passwordFile = "/tmp/secret.key"; # Interactive
                 settings = {
                   allowDiscards = true;
                   keyFile = "/tmp/secret.key";

--- a/example/luks-interactive-login.nix
+++ b/example/luks-interactive-login.nix
@@ -22,7 +22,6 @@
                 type = "luks";
                 name = "crypted";
                 settings.allowDiscards = true;
-                passwordFile = "/tmp/secret.key";
                 content = {
                   type = "filesystem";
                   format = "ext4";
@@ -34,5 +33,12 @@
         };
       };
     };
+  };
+
+  # If we don't set passwordFile above, we will be interactively prompted by the
+  # disko script to set the LUKS password. However, as passwordFile is necessary
+  # for installTest we set it here.
+  disko.tests.extraDiskoConfig = {
+    devices.disk.vdb.content.partitions.luks.content.passwordFile = "/tmp/secret.key";
   };
 }

--- a/example/swap.nix
+++ b/example/swap.nix
@@ -41,6 +41,26 @@
           };
         };
       };
+      vdc = {
+        device = "/dev/vdc";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            bigSwap = {
+              size = "16G";
+              content = {
+                type = "swap";
+              };
+            };
+          };
+        };
+      };
     };
+  };
+
+  disko.tests.extraDiskoConfig = {
+    # We need to override the partition size as it is too big for the installTest.
+    devices.disk.vdc.content.partitions.bigSwap.size = "1G";
   };
 }

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -45,6 +45,7 @@ let
       { name
       , disko-config
       , extendModules ? null
+      , extraDiskoConfig ? { }
       , pkgs ? import <nixpkgs> { }
       , extraTestScript ? ""
       , bootCommands ? ""
@@ -74,10 +75,13 @@ let
             importedDiskoConfig { inherit lib; }
           else
             importedDiskoConfig;
-        testConfigInstall = testLib.prepareDiskoConfig diskoConfigWithArgs (lib.tail testLib.devices);
+
+        extendedDiskoConfigWithArgs = lib.recursiveUpdate diskoConfigWithArgs { disko = extraDiskoConfig; };
+
+        testConfigInstall = testLib.prepareDiskoConfig extendedDiskoConfigWithArgs (lib.tail testLib.devices);
         # we need to shift the disks by one because the first disk is the /dev/vda of the test runner
         # so /dev/vdb becomes /dev/vda etc.
-        testConfigBooted = testLib.prepareDiskoConfig diskoConfigWithArgs testLib.devices;
+        testConfigBooted = testLib.prepareDiskoConfig extendedDiskoConfigWithArgs testLib.devices;
 
         tsp-generator = pkgs.callPackage ../. { checked = true; };
         tsp-format = (tsp-generator.formatScript testConfigInstall) pkgs;

--- a/module.nix
+++ b/module.nix
@@ -77,6 +77,13 @@ in
           machine.succeed("test -e /var/secrets/my.secret")
         '';
       };
+      extraDiskoConfig = lib.mkOption {
+        description = ''
+          Extra disko configuration when running the tests.
+        '';
+        type = lib.types.attrs;
+        default = { };
+      };
       extraConfig = lib.mkOption {
         description = ''
           Extra NixOS config for your test. Can be used to specify a different luks key for tests.
@@ -102,10 +109,10 @@ in
 
       installTest = diskoLib.testLib.makeDiskoTest {
         inherit extendModules pkgs;
+        inherit (cfg.tests) efi extraDiskoConfig;
         name = "${config.networking.hostName}-disko";
         disko-config = builtins.removeAttrs config [ "_module" ];
         testMode = "direct";
-        efi = cfg.tests.efi;
         extraSystemConfig = cfg.tests.extraConfig;
         extraTestScript = cfg.tests.extraChecks;
       };

--- a/tests/luks-interactive-login.nix
+++ b/tests/luks-interactive-login.nix
@@ -1,10 +1,13 @@
 { pkgs ? import <nixpkgs> { }
 , diskoLib ? pkgs.callPackage ../lib { }
 }:
-diskoLib.testLib.makeDiskoTest {
+diskoLib.testLib.makeDiskoTest (let
+  disko-config = import ../example/luks-interactive-login.nix;
+in {
   inherit pkgs;
   name = "luks-interactive-login";
-  disko-config = ../example/luks-interactive-login.nix;
+  inherit disko-config;
+  inherit (disko-config.disko.tests) extraDiskoConfig;
   extraTestScript = ''
     machine.succeed("cryptsetup isLuks /dev/vda2");
   '';
@@ -12,4 +15,4 @@ diskoLib.testLib.makeDiskoTest {
     machine.wait_for_console_text("vda")
     machine.send_console("secretsecret\n")
   '';
-}
+})

--- a/tests/swap.nix
+++ b/tests/swap.nix
@@ -1,10 +1,13 @@
 { pkgs ? import <nixpkgs> { }
 , diskoLib ? pkgs.callPackage ../lib { }
 }:
-diskoLib.testLib.makeDiskoTest {
+diskoLib.testLib.makeDiskoTest (let
+  disko-config = import ../example/swap.nix;
+in {
   inherit pkgs;
   name = "swap";
-  disko-config = ../example/swap.nix;
+  inherit disko-config;
+  inherit (disko-config.disko.tests) extraDiskoConfig;
   extraTestScript = ''
     import json
     machine.succeed("mountpoint /");
@@ -16,4 +19,4 @@ diskoLib.testLib.makeDiskoTest {
   extraSystemConfig = {
     environment.systemPackages = [ pkgs.jq ];
   };
-}
+})


### PR DESCRIPTION
The goal of this PR is to add an interface for end users to be able to override the disko config for disko-based tests like `system.build.installTest`.

I modified some examples to intentionally fail so that we can add test-specific overrides in the same file to show end users examples of overriding the disko config just for tests. 

I chose to not make `makeDiskoTest` aware of `disko-config.disko.tests.extraDiskoConfig` to simplify the merging logic, however that means callers of `makeDiskoTest` need to set `extraDiskoConfig` from `disko.tests.extraDiskoConfig` if they're using standalone files like the tests inside this repo.

I'm not really sure if this PR is the right way to implement this as currently it feels like `makeDiskoTest` is just a poor man's module system:

https://github.com/nix-community/disko/blob/9ab96378f8cf602d5f3ce5a32f2c339509288d8e/lib/tests.nix#L44-L80

and as I'm merging values manually, it makes it feel like that even more:

https://github.com/nix-community/disko/blob/6b98b81b9ce78e5ba3d6e54d6c7830b7cefcc585/lib/tests.nix#L79