### PR TITLE
fix broken fallback

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -11,11 +11,11 @@ in
 {
   options.disko = {
     extraRootModules = lib.mkOption {
-      type = lib.types.listOf lib.types.str ;
+      type = lib.types.listOf lib.types.str;
       description = ''
         extra modules to pass to the vmTools.runCommand invocation in the make-disk-image.nix builder
       '';
-      default = [];
+      default = [ ];
     };
     memSize = lib.mkOption {
       type = lib.types.int;
@@ -34,7 +34,7 @@ in
       description = ''
         list of extra packages to make available in the make-disk-image.nix VM builder, an example might be f2fs-tools
       '';
-      default = [];
+      default = [ ];
     };
     rootMountPoint = lib.mkOption {
       type = lib.types.str;
@@ -90,8 +90,8 @@ in
     system.build = (cfg.devices._scripts { inherit pkgs; checked = cfg.checkScripts; }) // {
 
       # we keep these old outputs for compatibility
-      disko = builtins.trace "the .disko output is deprecated, please use .diskoScript instead" (cfg.devices._scripts pkgs).diskoScript;
-      diskoNoDeps = builtins.trace "the .diskoNoDeps output is deprecated, please use .diskoScriptNoDeps instead" (cfg.devices._scripts pkgs).diskoScriptNoDeps;
+      disko = builtins.trace "the .disko output is deprecated, please use .diskoScript instead" (cfg.devices._scripts { inherit pkgs; }).diskoScript;
+      diskoNoDeps = builtins.trace "the .diskoNoDeps output is deprecated, please use .diskoScriptNoDeps instead" (cfg.devices._scripts { inherit pkgs; }).diskoScriptNoDeps;
 
       diskoImages = diskoLib.makeDiskImages {
         nixosConfig = args;


### PR DESCRIPTION
fixes an error when using this minimal configuration:

```nix
let
  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-23.11") { };
  disko = fetchTarball "https://github.com/nix-community/disko/tarball/master";
in
pkgs.nixos {
  imports = [
    "${disko}/module.nix"
    "${disko}/example/hybrid.nix"
  ];
}
```

when running:

```console
$ nix-build
...
error: 'default' at /nix/store/y981rwszq9yi36rvvz2vrr6hb22si0hc-source/lib/default.nix:391:23 called with unexpected argument 'system'
```