### PR TITLE
zfs: respect `canmount`

### DIFF
--- a/example/non-root-zfs.nix
+++ b/example/non-root-zfs.nix
@@ -59,6 +59,22 @@
           };
         };
       };
+      a = {
+        type = "disk";
+        device = "/dev/sda";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "storage2";
+              };
+            };
+          };
+        };
+      };
     };
     zpool = {
       storage = {
@@ -70,6 +86,20 @@
           dataset = {
             type = "zfs_fs";
             mountpoint = "/storage/dataset";
+          };
+        };
+      };
+      storage2 = {
+        type = "zpool";
+        mountpoint = "/storage2";
+        rootFsOptions = {
+          canmount = "off";
+        };
+
+        datasets = {
+          dataset = {
+            type = "zfs_fs";
+            mountpoint = "/storage2/dataset";
           };
         };
       };

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -67,9 +67,9 @@
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
           ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
           "''${zfs_devices[@]}"
-        ${lib.optionalString ((config.rootFsOptions.mountpoint or "") != "none") ''
+        if [[ $(zfs get -H mounted ${config.name} | cut -f3) == "yes" ]]; then
           zfs unmount ${config.name}
-        ''}
+        fi
         ${lib.concatMapStrings (dataset: dataset._create) (lib.attrValues config.datasets)}
       '';
     };

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -85,32 +85,13 @@
               zpool import -l -R ${rootMountPoint} '${config.name}'
             ${lib.concatMapStrings (x: x.dev or "") (lib.attrValues datasetMounts)}
           '';
-          fs = (datasetMounts.fs or { }) // lib.optionalAttrs (config.mountpoint != null) {
-            ${config.mountpoint} = ''
-              if ! findmnt ${config.name} "${rootMountPoint}${config.mountpoint}" >/dev/null 2>&1; then
-                mount ${config.name} "${rootMountPoint}${config.mountpoint}" \
-                  ${lib.optionalString ((config.options.mountpoint or "") != "legacy") "-o zfsutil"} \
-                  ${lib.concatMapStringsSep " " (opt: "-o ${opt}") config.mountOptions} \
-                  -o X-mount.mkdir \
-                  -t zfs
-              fi
-            '';
-          };
+          inherit (datasetMounts) fs;
         };
     };
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
-      default = [
-        (map (dataset: dataset._config) (lib.attrValues config.datasets))
-        (lib.optional (config.mountpoint != null) {
-          fileSystems.${config.mountpoint} = {
-            device = config.name;
-            fsType = "zfs";
-            options = config.mountOptions ++ lib.optional ((config.options.mountpoint or "") != "legacy") "zfsutil";
-          };
-        })
-      ];
+      default = map (dataset: dataset._config) (lib.attrValues config.datasets);
       description = "NixOS configuration";
     };
     _pkgs = lib.mkOption {
@@ -119,6 +100,16 @@
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
       default = pkgs: [ pkgs.util-linux ] ++ lib.flatten (map (dataset: dataset._pkgs pkgs) (lib.attrValues config.datasets));
       description = "Packages";
+    };
+  };
+
+  config = {
+    datasets."__root" = {
+      _name = config.name;
+      _create = "";
+      type = "zfs_fs";
+      mountpoint = config.mountpoint;
+      options = config.rootFsOptions;
     };
   };
 }

--- a/tests/non-root-zfs.nix
+++ b/tests/non-root-zfs.nix
@@ -14,13 +14,35 @@ diskoLib.testLib.makeDiskoTest {
     filesystem = machine.execute("stat --file-system --format=%T /mnt/storage")[1].rstrip()
     print(f"/mnt/storage {filesystem=}")
     assert filesystem == "zfs", "/mnt/storage is not ZFS"
+
+    machine.fail("mountpoint /mnt/storage2")
+    machine.succeed("mountpoint /mnt/storage2/dataset")
+
+    filesystem = machine.execute("stat --file-system --format=%T /mnt/storage2")[1].rstrip()
+    print(f"/mnt/storage2 {filesystem=}")
+    assert filesystem != "zfs", "/mnt/storage should not be ZFS"
+
+    filesystem = machine.execute("stat --file-system --format=%T /mnt/storage2/dataset")[1].rstrip()
+    print(f"/mnt/storage2/dataset {filesystem=}")
+    assert filesystem == "zfs", "/mnt/storage/dataset is not ZFS"
   '';
   extraTestScript = ''
     machine.succeed("mountpoint /storage")
     machine.succeed("mountpoint /storage/dataset")
 
     filesystem = machine.execute("stat --file-system --format=%T /storage")[1].rstrip()
-    print(f"/mnt/storage {filesystem=}")
+    print(f"/storage {filesystem=}")
     assert filesystem == "zfs", "/storage is not ZFS"
+
+    machine.fail("mountpoint /storage2")
+    machine.succeed("mountpoint /storage2/dataset")
+
+    filesystem = machine.execute("stat --file-system --format=%T /storage2")[1].rstrip()
+    print(f"/storage2 {filesystem=}")
+    assert filesystem != "zfs", "/storage should not be ZFS"
+
+    filesystem = machine.execute("stat --file-system --format=%T /storage2/dataset")[1].rstrip()
+    print(f"/storage2/dataset {filesystem=}")
+    assert filesystem == "zfs", "/storage/dataset is not ZFS"
   '';
 }


### PR DESCRIPTION
-  tests: check `canmount` ZFS flag is respected
- zpool: only `unmount` when root dataset is mounted
Fixes #486
- zfs: respect `canmount`
Also refactor `zpool` type to use `zfs_fs` to construct the root dataset
for the zpool, which means we no longer need to duplicate the dataset
create and mount logic inside the `zpool` type.

cc @phaer