### PR TITLE
Fix missing jq

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -446,7 +446,7 @@ let
 
               # shellcheck disable=SC2043
               for dev in ${toString (lib.catAttrs "device" (lib.attrValues devices.disk))}; do
-                ${../disk-deactivate}/disk-deactivate "$dev"
+                PATH=$PATH:${lib.makeBinPath (with pkgs; [ jq ])} ${../disk-deactivate}/disk-deactivate "$dev"
               done
             '';
           };


### PR DESCRIPTION
I got the following issue on a minimal live iso:

```
+ lsblk --output-all --json
+ bash -x
++ dirname /nix/store/r3xam6azp7zcd8a2ybwqdnqv0iliggl1-disk-deactivate/disk-deactivate
+ jq -r --arg disk_to_clear /dev/sda -f /nix/store/r3xam6azp7zcd8a2ybwqdnqv0iliggl1-disk-deactivate/disk-deactivate.jq
/nix/store/r3xam6azp7zcd8a2ybwqdnqv0iliggl1-disk-deactivate/disk-deactivate: line 7: jq: command not found
++ mktemp -d
+ disko_devices_dir=/tmp/tmp.TuXBVEvKX6
+ trap 'rm -rf "$disko_devices_dir"' EXIT
```