### PR TITLE
docs: mention EF00 partition type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A simple disko configuration may look like this:
      type = "gpt";
      partitions = {
       ESP = {
+       type = "EF00";
        size = "500M";
        content = {
         type = "filesystem";


### PR DESCRIPTION
Otherwise systemd-boot will refuse to install the bootloader.