### PR TITLE
wipe device before creating partition table

### DIFF
--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -82,6 +82,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
+        wipefs --all --force ${config.device}
         parted -s ${config.device} -- mklabel ${config.format}
         ${lib.concatStrings (map (partition: ''
           ${lib.optionalString (config.format == "gpt") ''


### PR DESCRIPTION
this erases not only pre-existing filesystems, but all magic strings recognized by libblkid(3), including raid superblocks