### PR TITLE
deactivate: stop raid if disk is a member of it

### DIFF
--- a/disk-deactivate/disk-deactivate.jq
+++ b/disk-deactivate/disk-deactivate.jq
@@ -27,7 +27,7 @@ def deactivate:
   if .type == "disk" then
     [
       # If this disk is a member of raid, stop that raid
-      "mdadm --stop $(lsblk \(.path) -l -p -o type,name | awk 'match($1,\"raid.*\") {print $2}')",
+      "lsblk \(.path) -l -p -o type,name | awk 'match($1,\"raid.*\") {print $2}' | xargs -r mdadm --stop",
       # Remove all file-systems and other magic strings
       "wipefs --all -f \(.path)",
       # Remove the MBR bootstrap code

--- a/disk-deactivate/disk-deactivate.jq
+++ b/disk-deactivate/disk-deactivate.jq
@@ -27,7 +27,8 @@ def deactivate:
   if .type == "disk" then
     [
       # If this disk is a member of raid, stop that raid
-      "lsblk \(.path) -l -p -o type,name | awk 'match($1,\"raid.*\") {print $2}' | xargs -r mdadm --stop",
+      "md_dev=$(lsblk \(.path) -l -p -o type,name | awk 'match($1,\"raid.*\") {print $2}')",
+      "if [[ -n \"${md_dev}\" ]]; then umount \"$md_dev\"; mdadm --stop \"$md_dev\"; fi",
       # Remove all file-systems and other magic strings
       "wipefs --all -f \(.path)",
       # Remove the MBR bootstrap code

--- a/disk-deactivate/disk-deactivate.jq
+++ b/disk-deactivate/disk-deactivate.jq
@@ -26,6 +26,9 @@ def remove:
 def deactivate:
   if .type == "disk" then
     [
+      # If this disk is a member of raid, stop that raid
+      "mdadm --stop $(lsblk \(.path) -l -p -o type,name | awk 'match($1,\"raid.*\") {print $2}')",
+      # Remove all file-systems and other magic strings
       "wipefs --all -f \(.path)",
       # Remove the MBR bootstrap code
       "dd if=/dev/zero of=\(.path) bs=440 count=1"


### PR DESCRIPTION
this is useful in cases where the target machine has a pre-configured RAID setup, as otherwise disko would wipe the partition tables and create new ones but would not be able to inform the kernel about it, as the old raid was still in use.

it's the spiritual successor to #500 ;)
