### PR TITLE
make-disk-image: umount after install and explicitly set raw format

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -64,7 +64,7 @@ let
     ${systemToInstall.config.system.build.nixos-install}/bin/nixos-install --system ${systemToInstall.config.system.build.toplevel} --keep-going --no-channel-copy -v --no-root-password --option binary-caches ""
     umount -Rv ${systemToInstall.config.disko.rootMountPoint}
   '';
-  QEMU_OPTS = lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report") (lib.attrValues nixosConfig.config.disko.devices.disk);
+  QEMU_OPTS = lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report,format=raw") (lib.attrValues nixosConfig.config.disko.devices.disk);
 in
 {
   pure = vmTools.runInLinuxVM (pkgs.runCommand name

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -62,6 +62,7 @@ let
   '';
   installer = ''
     ${systemToInstall.config.system.build.nixos-install}/bin/nixos-install --system ${systemToInstall.config.system.build.toplevel} --keep-going --no-channel-copy -v --no-root-password --option binary-caches ""
+    umount -Rv ${systemToInstall.config.disko.rootMountPoint}
   '';
   QEMU_OPTS = lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report") (lib.attrValues nixosConfig.config.disko.devices.disk);
 in


### PR DESCRIPTION
This PR includes two minor changes to the `make-disk-image` script.

The `vmTools` in nixpkgs shuts the VM down with `poweroff -f`, which does not cleanly umount the filesystems. This may lead to filesystem corruption on the newly created image. To fix this, we add an explicit `umount` call after the installer is finished.

QEMU warns if `format=raw` is implied, and protects block 0 from getting overwritten. I did not encounter any issues because of that protection, but I think it is better to be explicit here. It also gets rid of the warning.