### PR TITLE
make-disk-image: optionally include ZFS module in kernel

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -10,7 +10,8 @@ let
   vmTools = pkgs.vmTools.override {
     rootModules = ["9p" "9pnet_virtio" "virtio_pci" "virtio_blk"] ++ nixosConfig.config.disko.extraRootModules;
     kernel = pkgs.aggregateModules
-    (with nixosConfig.config.boot.kernelPackages; [ kernel ]);
+    (with nixosConfig.config.boot.kernelPackages; [ kernel ]
+      ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);
   };
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig nixosConfig.config diskoLib.testLib.devices;
   systemToInstall = nixosConfig.extendModules {


### PR DESCRIPTION
`(with nixosConfig.config.boot.kernelPackages; [ kernel ])` alone does not include the ZFS kernel module. We only want to include it if `extraRootModules` includes `zfs`, because ZFS might not be available for the specified kernel.