### PR TITLE
Rework Hybrid MBR https://github.com/nix-community/disko/pull/168

### DIFF
--- a/disk-deactivate/disk-deactivate.jq
+++ b/disk-deactivate/disk-deactivate.jq
@@ -24,7 +24,7 @@ def remove:
 ;
 
 def deactivate:
-  if .type == "disk" then
+  if .type == "disk" or .type == "loop" then
     [
       # If this disk is a member of raid, stop that raid
       "md_dev=$(lsblk \(.path) -l -p -o type,name | awk 'match($1,\"raid.*\") {print $2}')",
@@ -54,7 +54,7 @@ def deactivate:
       "mdadm --stop \(.name)"
     ]
   else
-    []
+    ["echo Warning: unknown type '\(.type)'. Consider handling this in https://github.com/nix-community/disko/blob/master/disk-deactivate/disk-deactivate.jq"]
   end
 ;
 

--- a/example/hybrid-mbr.nix
+++ b/example/hybrid-mbr.nix
@@ -7,12 +7,6 @@
         content = {
           type = "gpt";
           efiGptPartitionFirst = false;
-          hybrid_partitions = [
-            {
-              mbrPartitionType = "0x0c";
-              mbrBootableFlag = false;
-            }
-          ];
           partitions = {
             TOW-BOOT-FI = {
               priority = 1;
@@ -22,6 +16,10 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = null;
+              };
+              hybrid = {
+                mbrPartitionType = "0x0c";
+                mbrBootableFlag = false;
               };
             };
             ESP = {

--- a/example/hybrid-mbr.nix
+++ b/example/hybrid-mbr.nix
@@ -1,0 +1,49 @@
+{disks ? ["/dev/sda"], ...}: {
+  disko.devices = {
+    disk = {
+      main = {
+        type = "disk";
+        device = builtins.elemAt disks 0;
+        content = {
+          type = "gpt";
+          efiGptPartitionFirst = false;
+          hybrid_partitions = [
+            {
+              mbrPartitionType = "0x0c";
+              mbrBootableFlag = false;
+            }
+          ];
+          partitions = {
+            TOW-BOOT-FI = {
+              priority = 1;
+              type = "EF00";
+              size = "32M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = null;
+              };
+            };
+            ESP = {
+              type = "EF00";
+              size = "512M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -194,7 +194,7 @@ let
           || lib.hasSuffix "Hook" n
           || isAttrsOfSubmodule o
           # TODO don't hardcode diskoLib.subType options.
-          || n == "content" || n == "partitions" || n == "datasets" || n == "swap" || n == "hybrid_partitions"
+          || n == "content" || n == "partitions" || n == "datasets" || n == "swap"
         );
       in
       lib.toShellVars

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,9 +84,11 @@ let
         "${dev}${toString index}" # /dev/md/raid1 style
       else if match "/dev/mapper/.+" dev != null then
         "${dev}${toString index}" # /dev/mapper/vg-lv1 style
+      else if match "/dev/loop[[:digit:]]+" dev != null
+        then "${dev}p${toString index}" # /dev/mapper/vg-lv1 style
       else
         abort ''
-          ${dev} seems not to be a supported disk format. Please add this to disko in https://github.com/nix-community/disko/blob/master/types/default.nix
+          ${dev} seems not to be a supported disk format. Please add this to disko in https://github.com/nix-community/disko/blob/master/lib/default.nix
         '';
 
     /* get the index an item in a list
@@ -192,7 +194,7 @@ let
           || lib.hasSuffix "Hook" n
           || isAttrsOfSubmodule o
           # TODO don't hardcode diskoLib.subType options.
-          || n == "content" || n == "partitions" || n == "datasets" || n == "swap"
+          || n == "content" || n == "partitions" || n == "datasets" || n == "swap" || n == "hybrid_partitions"
         );
       in
       lib.toShellVars

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -146,7 +146,6 @@ in
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        sgdisk -Z ${config.device}
         ${lib.concatStrings (map (partition: ''
           sgdisk \
             --align-end \

--- a/tests/hybrid-mbr.nix
+++ b/tests/hybrid-mbr.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "hybrid-mbr";
+  disko-config = ../example/hybrid-mbr.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+  '';
+}


### PR DESCRIPTION
Since https://github.com/nix-community/disko/pull/168 stalled I decided to rework it to the current status quo.
Changes compared to the previous approach:
- Moved the hybrid mbr code to the gpt module. That is way cleaner than introducing new types imho. The types just make sense when combined with gpt anyway.
- Removed the need for the `gptPartitionNumber` as we now take the index of the list entry.

@oneingan Hope you don't mind.