### PR TITLE
lib/types/gpt: do not hard-code alignment to 2048 sectors

### DIFF
--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -110,7 +110,6 @@ in
       default = ''
         ${lib.concatStrings (map (partition: ''
           sgdisk \
-            --set-alignment=2048 \
             --align-end \
             --new=${toString partition._index}:${partition.start}:${partition.end} \
             --change-name=${toString partition._index}:${partition.label} \


### PR DESCRIPTION
On 4Kn disks, 2048-sector alignment is equivalent to 8 MiB which is
excessive. Moreover, there is no point in specifying _any_ alignment
at all because sgdisk defaults to 1 MiB already.

Fixes #497.