### PR TITLE
Prevent `disk-deactivate` from failing when `disko` is run in a systemd service

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Nix community projects
+Copyright (c) 2018, 2019, 2022–2024 Nix community projects
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/disk-deactivate/disk-deactivate
+++ b/disk-deactivate/disk-deactivate
@@ -3,6 +3,6 @@ set -efux -o pipefail
 # dependencies: bash jq util-linux lvm2 mdadm zfs
 disk=$(realpath "$1")
 
-lsblk -a -f >/dev/stderr
+lsblk -a -f >&2
 lsblk --output-all --json | jq -r --arg disk_to_clear "$disk" -f "$(dirname "$0")/disk-deactivate.jq" | bash -x
-lsblk -a -f >/dev/stderr
+lsblk -a -f >&2


### PR DESCRIPTION
See the individual commit messages for details. I ran into this issue while trying to create a custom NixOS installation ISO that can do unattended installs.
