### PR TITLE
Fix manual build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,10 @@
         in
         # FIXME: aarch64-linux seems to hang on boot
         nixpkgs.lib.optionalAttrs pkgs.hostPlatform.isx86_64 (nixosTests // { inherit disko-install; }) //
-        pkgs.lib.optionalAttrs (!pkgs.buildPlatform.isRiscV64 && !pkgs.hostPlatform.isx86_32) { inherit shellcheck; });
+        pkgs.lib.optionalAttrs (!pkgs.buildPlatform.isRiscV64 && !pkgs.hostPlatform.isx86_32) {
+          inherit shellcheck;
+          inherit (self.packages.${system}) disko-doc;
+        });
 
       nixosConfigurations.testmachine = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";

--- a/lib/types/lvm_vg.nix
+++ b/lib/types/lvm_vg.nix
@@ -22,6 +22,9 @@
           priority = lib.mkOption {
             type = lib.types.int;
             default = if (lib.hasInfix "100%" lv.config.size) then 9001 else 1000;
+            defaultText = lib.literalExpression ''
+              if (lib.hasInfix "100%" lv.config.size) then 9001 else 1000
+            '';
             description = "Priority of the logical volume, smaller values are created first";
           };
           size = lib.mkOption {


### PR DESCRIPTION
The option `disko.devices.lvm_vg.<name>.lvs.<name>.priority` depends on a different option that's unset by default breaking the manual build like this:

    … while evaluating the attribute 'optionalValue.value'

     at /nix/store/lwyjz70qh12nq6cb7fixl85vryzxqm3c-source/lib/modules.nix:856:5:

      855|
      856|     optionalValue =
         |     ^
      857|       if isDefined then { value = mergedValue; }

    … while evaluating a branch condition

     at /nix/store/lwyjz70qh12nq6cb7fixl85vryzxqm3c-source/lib/modules.nix:857:7:

      856|     optionalValue =
      857|       if isDefined then { value = mergedValue; }
         |       ^
      858|       else {};

    (stack trace truncated; use '--show-trace' to show the full trace)

    error: The option `disko.devices.lvm_vg.<name>.lvs.<name>.size' is used but not defined.

This is especially noticeable when using `documentation.nixos.includeAllModules` locally.

Fixed the issue itself by adding a `defaultText` and added the `disko-doc` job to the `checks` output so that CI hopefully catches this from now on.

cc @Lassulus 