### PR TITLE
disko-install: fix case where lib in NixOS is not defined

### DIFF
--- a/disko
+++ b/disko
@@ -104,6 +104,14 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+nixBuild() {
+  if command -v nom-build > /dev/null; then
+    nom-build "$@"
+  else
+    nix-build "$@"
+  fi
+}
+
 if ! { [[ $mode = "format" ]] || [[ $mode = "mount" ]] || [[ $mode = "disko" ]] || [[ $mode = "create" ]] || [[ $mode = "zap_create_mount" ]] ; }; then
   abort "mode must be either format, mount or disko"
 fi
@@ -131,7 +139,7 @@ else
 fi
 
 # The "--impure" is still pure, as the path is within the nix store.
-script=$(nix-build "${libexec_dir}"/cli.nix \
+script=$(nixBuild "${libexec_dir}"/cli.nix \
   --no-out-link \
   --impure \
   --argstr mode "$mode" \

--- a/disko
+++ b/disko
@@ -118,6 +118,9 @@ if [[ -n "${flake+x}" ]]; then
     echo "For example, to use the output diskoConfigurations.foo from the flake.nix, append \"#foo\" to the flake-uri."
     exit 1
   fi
+  if [[ -e "$flake" ]]; then
+    flake=$(realpath "$flake")
+  fi
   nix_args+=("--arg" "flake" "\"$flake\"")
   nix_args+=("--argstr" "flakeAttr" "$flakeAttr")
   nix_args+=(--extra-experimental-features flakes)

--- a/disko-install
+++ b/disko-install
@@ -151,6 +151,11 @@ main() {
     flake="${BASH_REMATCH[1]}"
     flakeAttr="${BASH_REMATCH[2]}"
   fi
+
+  if [[ -e "$flake" ]]; then
+    flake=$(realpath "$flake")
+  fi
+
   if [[ -z ${flakeAttr-} ]]; then
     echo "Please specify the name of the NixOS configuration to be installed, as a URI fragment in the flake-uri." >&2
     echo 'For example, to use the output nixosConfigurations.foo from the flake.nix, append "#foo" to the flake-uri.' >&2

--- a/disko-install
+++ b/disko-install
@@ -139,6 +139,14 @@ cleanupMountPoint() {
   rmdir "${mountPoint}"
 }
 
+nixBuild() {
+  if command -v nom-build > /dev/null; then
+    nom-build "$@"
+  else
+    nix-build "$@"
+  fi
+}
+
 main() {
   parseArgs "$@"
 
@@ -168,7 +176,7 @@ main() {
   # shellcheck disable=SC2064
   trap "cleanupMountPoint ${escapeMountPoint}" EXIT
 
-  outputs=$(nix-build "${libexec_dir}"/install-cli.nix \
+  outputs=$(nixBuild "${libexec_dir}"/install-cli.nix \
     "${nix_args[@]}" \
     --no-out-link \
     --impure \

--- a/install-cli.nix
+++ b/install-cli.nix
@@ -8,7 +8,7 @@ let
   originalSystem = (builtins.getFlake "${flake}").nixosConfigurations."${flakeAttr}";
   diskoSystem =
     let
-      lib = originalSystem.lib;
+      lib = originalSystem.pkgs.lib;
 
       modifiedDisks = builtins.mapAttrs
         (name: value: let


### PR DESCRIPTION
This seems like a recent addition that we don't have on all NixOS machines.