### PR TITLE
types zpool: create pool if device is a zfs_member

### DIFF
--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -73,6 +73,9 @@
             elif (blkid "$dev" -o export | grep '^PTUUID='); then
               echo "device $dev already has a partuuid, skipping creating zpool ${config.name}" >&2
               continue=0
+            elif (blkid "$dev" -o export | grep '^TYPE=zfs_member'); then
+              # zfs_member is a zfs partition, so we try to add the device to the pool
+              :
             elif (blkid "$dev" -o export | grep '^TYPE='); then
               echo "device $dev already has a partition, skipping creating zpool ${config.name}" >&2
               continue=0


### PR DESCRIPTION
fix https://github.com/nix-community/disko/issues/576

Not sure why the device would already have a type though, but it should be safe to continue in case the partition is a zfs member