### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -198,6 +198,6 @@ take care of that automatically.
 f) Finish the installation and reboot your machine,
 
 ```console
-nixos-install
+nixos-install --root /mnt
 reboot
 ```


### PR DESCRIPTION
Fix `nixos-install` command invocation, it must use the root dir defined on `nixos-generate-config`