### PR TITLE
Add missing dependency gnused

### DIFF
--- a/disk-deactivate/disk-deactivate
+++ b/disk-deactivate/disk-deactivate
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -efux -o pipefail
-# dependencies: bash jq util-linux lvm2 mdadm zfs gnugrep
+# dependencies: bash jq util-linux lvm2 mdadm zfs gnugrep sed
 disk=$(realpath "$1")
 
 lsblk -a -f >&2

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -400,6 +400,7 @@ let
                   lvm2
                   bash
                   jq
+                  gnused
                 ])}:$PATH
                 ${cfg.config._destroy}
               '';


### PR DESCRIPTION
gnused is used in the disk-deactivate.jq script, but was not defined in the list of dependencies.