### PR TITLE
Use existing bash instance when running destroyScript

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -449,7 +449,7 @@ let
 
               # shellcheck disable=SC2043
               for dev in ${toString (lib.catAttrs "device" (lib.attrValues devices.disk))}; do
-                ${../disk-deactivate}/disk-deactivate "$dev"
+                $BASH ${../disk-deactivate}/disk-deactivate "$dev"
               done
             '';
           };


### PR DESCRIPTION
The destroy script already has a bash interpreter in use, but when the `disk-deactivate` script is ran, it calls out to /usr/bin/env to query for a bash interpreter. When running the destroyScript in unique places (such as the stage-1 initrd), /usr/bin/env might not exist, so we can make destroyScript more self-contained by reusing the same bash.