### PR TITLE
types btrfs: fix format without swap or subvolumes

### DIFF
--- a/example/btrfs-only-root-subvolume.nix
+++ b/example/btrfs-only-root-subvolume.nix
@@ -1,0 +1,37 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        type = "disk";
+        device = "/dev/disk/by-diskseq/1";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              priority = 1;
+              name = "ESP";
+              start = "1M";
+              end = "128M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "btrfs";
+                extraArgs = [ "-f" ]; # Override existing partition
+                mountpoint = "/";
+                mountOptions = [ "compress=zstd" "noatime" ];
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}
+

--- a/tests/btrfs-only-root-subvolume.nix
+++ b/tests/btrfs-only-root-subvolume.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "btrfs-only-root-subvolume";
+  disko-config = ../example/btrfs-only-root-subvolume.nix;
+  extraTestScript = ''
+    machine.succeed("btrfs subvolume list /");
+  '';
+}


### PR DESCRIPTION
Hi! Recently when trying to format a btrfs drive I ran into ```syntax error near unexpected token `fi'```.

It looks like #568 introduced a change that generates an empty if statement if neither the swap config or subvolumes are set and this just adds a guard to avoid adding that empty if block if neither are set.