### PR TITLE
disko-install: Add --system-option flag. Fix EF02 priority everywhere…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ A simple disko configuration may look like this:
 ```
 
 If you'd saved this configuration in /tmp/disk-config.nix, and wanted to create
-a disk named /dev/sda, you would run the following command to partition,
-format and mount the disk.
+a disk named /dev/sda, you would run the following command to partition, format
+and mount the disk.
 
 ```console
 sudo nix --experimental-features "nix-command flakes" run github:nix-community/disko -- --mode disko /tmp/disk-config.nix

--- a/disko-install
+++ b/disko-install
@@ -19,10 +19,7 @@ Usage: $0 [OPTIONS]
   --write-efi-boot-entries    Write EFI boot entries to the NVRAM of the system for the installed system.
                               Specify this option if you plan to boot from this disk on the current machine,
                               but not if you plan to move the disk to another machine.
-  --system-option KEY VALUE   Pass the specified system option to the NixOS configuration.
-                              This option can be specified multiple times.
-                              For example, to set the authorizedKeys, use
-                              --system-option users.users.root.openssh.authorizedKeys.keys '[ "ssh-rsa ..." ]'
+  --system-config JSON        Merges the specified JSON object into the NixOS configuration.
 EOF
 }
 
@@ -39,19 +36,6 @@ serialiaseArrayToNix() {
   echo "$nixExpr"
 }
 
-serialiaseArrayToNixUnquoted() {
-  local -n array=$1
-  nixExpr="{ "
-  # Iterate over the associative array to populate the Nix attrset string
-  for key in "${!array[@]}"; do
-    value=${array[$key]}
-    nixExpr+="${key} = ${value};"
-  done
-  nixExpr+="}"
-
-  echo "$nixExpr"
-}
-
 readonly libexec_dir="${0%/*}"
 
 nix_args=(
@@ -59,11 +43,12 @@ nix_args=(
   "--option" "no-write-lock-file" "true"
 )
 dry_run=
+extraSystemConfig="{}"
 diskoAttr=diskoScript
 writeEfiBootEntries=false
 declare -A diskMappings
 declare -A extraFiles
-declare -A extraSystemConfig
+
 
 parseArgs() {
   [[ $# -eq 0 ]] && {
@@ -113,14 +98,13 @@ parseArgs() {
       esac
       shift
       ;;
-    --system-option)
-      if [[ $# -lt 3 ]]; then
-        echo "Option $1 requires two arguments: key, value" >&2
+    --system-config)
+      if [[ $# -lt 2 ]]; then
+        echo "Option $1 requires one JSON argument." >&2
         exit 1
       fi
       # shellcheck disable=SC2034
-      extraSystemConfig[$2]=$3
-      shift
+      extraSystemConfig="$2"
       shift
       ;;
     --extra-files)
@@ -134,7 +118,7 @@ parseArgs() {
       ;;
     --option)
       if [[ $# -lt 3 ]]; then
-        echo "Option $1 requires an argument" >&2
+        echo "Option $1 requires two arguments: key, value" >&2
         exit 1
       fi
       nix_args+=(--option "$2" "$3")
@@ -221,7 +205,7 @@ main() {
     --argstr rootMountPoint "$mountPoint" \
     --arg writeEfiBootEntries "$writeEfiBootEntries" \
     --arg diskMappings "$(serialiaseArrayToNix diskMappings)" \
-    --arg extraSystemConfig "$(serialiaseArrayToNixUnquoted extraSystemConfig)" \
+    --argstr extraSystemConfig "$extraSystemConfig" \
     -A installToplevel \
     -A "$diskoAttr")
 

--- a/disko-install
+++ b/disko-install
@@ -19,6 +19,10 @@ Usage: $0 [OPTIONS]
   --write-efi-boot-entries    Write EFI boot entries to the NVRAM of the system for the installed system.
                               Specify this option if you plan to boot from this disk on the current machine,
                               but not if you plan to move the disk to another machine.
+  --system-option KEY VALUE   Pass the specified system option to the NixOS configuration.
+                              This option can be specified multiple times.
+                              For example, to set the authorizedKeys, use
+                              --system-option users.users.root.openssh.authorizedKeys.keys '[ "ssh-rsa ..." ]'
 EOF
 }
 
@@ -29,6 +33,19 @@ serialiaseArrayToNix() {
   for key in "${!array[@]}"; do
     value=${array[$key]}
     nixExpr+="\"${key//\"/\\\"}\" = \"${value//\"/\\\"}\"; "
+  done
+  nixExpr+="}"
+
+  echo "$nixExpr"
+}
+
+serialiaseArrayToNixUnquoted() {
+  local -n array=$1
+  nixExpr="{ "
+  # Iterate over the associative array to populate the Nix attrset string
+  for key in "${!array[@]}"; do
+    value=${array[$key]}
+    nixExpr+="${key} = ${value};"
   done
   nixExpr+="}"
 
@@ -46,6 +63,7 @@ diskoAttr=diskoScript
 writeEfiBootEntries=false
 declare -A diskMappings
 declare -A extraFiles
+declare -A extraSystemConfig
 
 parseArgs() {
   [[ $# -eq 0 ]] && {
@@ -93,6 +111,16 @@ parseArgs() {
         exit 1
         ;;
       esac
+      shift
+      ;;
+    --system-option)
+      if [[ $# -lt 3 ]]; then
+        echo "Option $1 requires two arguments: key, value" >&2
+        exit 1
+      fi
+      # shellcheck disable=SC2034
+      extraSystemConfig[$2]=$3
+      shift
       shift
       ;;
     --extra-files)
@@ -193,6 +221,7 @@ main() {
     --argstr rootMountPoint "$mountPoint" \
     --arg writeEfiBootEntries "$writeEfiBootEntries" \
     --arg diskMappings "$(serialiaseArrayToNix diskMappings)" \
+    --arg extraSystemConfig "$(serialiaseArrayToNixUnquoted extraSystemConfig)" \
     -A installToplevel \
     -A "$diskoAttr")
 

--- a/docs/disko-install.md
+++ b/docs/disko-install.md
@@ -1,10 +1,12 @@
 # disko-install
 
-**disko-install** enhances the normal `nixos-install` with disko's partitioning feature.
-It can be started from the NixOS installer but it can also be used to create bootable USB-Sticks from your normal workstation.
-Furthermore `disko-install` has a mount mode that will only mount but not destroy existing partitions.
-The mount mode can be used to mount and repair existing NixOS installations.
-This document provides a comprehensive guide on how to use **disko-install**, including examples for typical usage scenarios.
+**disko-install** enhances the normal `nixos-install` with disko's partitioning
+feature. It can be started from the NixOS installer but it can also be used to
+create bootable USB-Sticks from your normal workstation. Furthermore
+`disko-install` has a mount mode that will only mount but not destroy existing
+partitions. The mount mode can be used to mount and repair existing NixOS
+installations. This document provides a comprehensive guide on how to use
+**disko-install**, including examples for typical usage scenarios.
 
 ## Requirements
 
@@ -16,7 +18,8 @@ This document provides a comprehensive guide on how to use **disko-install**, in
 
 ### Fresh Installation
 
-For a fresh installation, where **disko-install** will handle partitioning and setting up the disk, use the following syntax:
+For a fresh installation, where **disko-install** will handle partitioning and
+setting up the disk, use the following syntax:
 
 ```console
 sudo nix run 'github:nix-community/disko#disko-install' -- --flake <flake-url>#<flake-attr> --disk <disk-name> <disk-device>
@@ -24,11 +27,11 @@ sudo nix run 'github:nix-community/disko#disko-install' -- --flake <flake-url>#<
 
 Example:
 
-First run `nixos-generate-config --root /tmp/config --no-filesystems` and
-edit `configuration.nix` to your liking.
+First run `nixos-generate-config --root /tmp/config --no-filesystems` and edit
+`configuration.nix` to your liking.
 
-Than add the following `flake.nix` inside `/tmp/config/etc/nixos`.
-In this example we assume a system that has been booted with EFI:
+Than add the following `flake.nix` inside `/tmp/config/etc/nixos`. In this
+example we assume a system that has been booted with EFI:
 
 ```nix
 {
@@ -53,6 +56,7 @@ In this example we assume a system that has been booted with EFI:
                   MBR = {
                     type = "EF02"; # for grub MBR
                     size = "1M";
+                    priority = 1; # Needs to be first partition
                   };
                   ESP = {
                     type = "EF00";
@@ -105,8 +109,8 @@ In our example, we want to install to a USB-stick (/dev/sda):
 $ sudo nix run 'github:nix-community/disko#disko-install' -- --flake '/tmp/config/etc/nixos#mymachine' --disk main /dev/sda
 ```
 
-Afterwards you can test your USB-stick by either selecting during the boot
-or attaching it to a qemu-vm:
+Afterwards you can test your USB-stick by either selecting during the boot or
+attaching it to a qemu-vm:
 
 ```
 $ sudo qemu-kvm -enable-kvm -hda /dev/sda
@@ -114,23 +118,25 @@ $ sudo qemu-kvm -enable-kvm -hda /dev/sda
 
 ### Persisting boot entries to EFI vars flash
 
-**disko-install** is designed for NixOS installations on portable storage or disks that may be transferred between computers.
-As such, it does not modify the host's NVRAM by default.
-To ensure your NixOS installation boots seamlessly on new hardware or to prioritize it in your current machine's boot order,
-use the --write-efi-boot-entries option:
+**disko-install** is designed for NixOS installations on portable storage or
+disks that may be transferred between computers. As such, it does not modify the
+host's NVRAM by default. To ensure your NixOS installation boots seamlessly on
+new hardware or to prioritize it in your current machine's boot order, use the
+--write-efi-boot-entries option:
 
 ```console
 $ sudo nix run 'github:nix-community/disko#disko-install' -- --write-efi-boot-entries --flake '/tmp/config/etc/nixos#mymachine' --disk main /dev/sda
 ```
 
-This command installs NixOS with **disko-install** and sets the newly installed system as the default boot option,
-without affecting the flexibility to boot from other devices if needed.
+This command installs NixOS with **disko-install** and sets the newly installed
+system as the default boot option, without affecting the flexibility to boot
+from other devices if needed.
 
 ### Using disko-install in an offline installer
 
-If you want to **disko-install** from a customer installer without internet, you need to make sure that
-next the toplevel of your NixOS closure that you plan to install, it also needs **diskoScript** and
-all the flake inputs for evaluation.
+If you want to **disko-install** from a customer installer without internet, you
+need to make sure that next the toplevel of your NixOS closure that you plan to
+install, it also needs **diskoScript** and all the flake inputs for evaluation.
 
 #### Example configuration to install
 
@@ -212,4 +218,6 @@ in
 }
 ```
 
-Also see the [NixOS test of disko-install](https://github.com/nix-community/disko/blob/master/tests/disko-install/default.nix) that also runs without internet.
+Also see the
+[NixOS test of disko-install](https://github.com/nix-community/disko/blob/master/tests/disko-install/default.nix)
+that also runs without internet.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,8 +70,8 @@ and made a note of its URL.
 Your configuration needs to be saved on the new machine for example
 as /tmp/disk-config.nix. You can do this using the `curl` command to download
 from the url you noted above, using the `-o` option to save the file as
-disk-config.nix. Your commands would look like this if you had chosen the
-hybrid layout:
+disk-config.nix. Your commands would look like this if you had chosen the hybrid
+layout:
 
 ```console
 cd /tmp
@@ -182,8 +182,8 @@ of the NixOS manual. The following configuration for `grub` works for both EFI
 and BIOS systems. Add this to your configuration.nix, commenting out the
 existing lines that configure `systemd-boot`. The entries will look like this:
 
-**Note:** Its not necessary to set `boot.loader.grub.device` here, since Disko will
-take care of that automatically.
+**Note:** Its not necessary to set `boot.loader.grub.device` here, since Disko
+will take care of that automatically.
 
 ```nix
 # ...

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -51,9 +51,11 @@ generate disk images:
 
 ### Generating the `.raw` VM Image
 
-1. **Create a NixOS configuration that includes the disko and the disk configuration of your choice**
+1. **Create a NixOS configuration that includes the disko and the disk
+   configuration of your choice**
 
-In the this example we create a flake containing a nixos configuration for `myhost`.
+In the this example we create a flake containing a nixos configuration for
+`myhost`.
 
 ```nix
 # save this as flake.nix
@@ -86,15 +88,15 @@ In the this example we create a flake containing a nixos configuration for `myho
 }
 ```
 
-2. **Build the disko image script:** Replace `myhost` in the command below with your
-   specific system configuration name:
+2. **Build the disko image script:** Replace `myhost` in the command below with
+   your specific system configuration name:
 
    ```console
    nix build .#nixosConfigurations.myhost.config.system.build.diskoImagesScript
    ```
 
-3. **Execute the disko image script:** Execute the generated disko image script. Running
-   `./result --help` will output the available options:
+3. **Execute the disko image script:** Execute the generated disko image script.
+   Running `./result --help` will output the available options:
 
    ```console
    ./result --help
@@ -124,9 +126,10 @@ In the this example we create a flake containing a nixos configuration for `myho
    sudo ./result --build-memory 2048
    ```
 
-   The script will generate the actual image outside of the nix store in the current working directory.
-   The create image names depend on the names used in `disko.devices.disk` attrset in the NixOS configuration.
-   In our code example it will produce the following image:
+   The script will generate the actual image outside of the nix store in the
+   current working directory. The create image names depend on the names used in
+   `disko.devices.disk` attrset in the NixOS configuration. In our code example it will
+   produce the following image:
 
    ```
    $ ls -la vdb.raw
@@ -142,8 +145,8 @@ In the this example we create a flake containing a nixos configuration for `myho
   ```
 
 - If the `.raw` image size is not optimal, use `--write-to-disk` to write
-  directly to a drive. This bypasses the `.raw` file generation, which saves on read/write operations
-  and is suitable for single disk setups.
+  directly to a drive. This bypasses the `.raw` file generation, which saves on
+  read/write operations and is suitable for single disk setups.
 
 ### Understanding the Image Generation Process
 

--- a/example/boot-raid1.nix
+++ b/example/boot-raid1.nix
@@ -38,6 +38,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              priority = 1; # Needs to be first partition
             };
             ESP = {
               size = "500M";

--- a/example/gpt-bios-compat.nix
+++ b/example/gpt-bios-compat.nix
@@ -11,6 +11,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              priority = 1; # Needs to be first partition
             };
             root = {
               size = "100%";

--- a/example/hybrid-tmpfs-on-root.nix
+++ b/example/hybrid-tmpfs-on-root.nix
@@ -9,6 +9,7 @@
           boot = {
             size = "1M";
             type = "EF02"; # for grub MBR
+            priority = 1; # Needs to be first partition
           };
           ESP = {
             name = "ESP";

--- a/example/hybrid.nix
+++ b/example/hybrid.nix
@@ -10,6 +10,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              priority = 1; # Needs to be first partition
             };
             ESP = {
               size = "512M";

--- a/example/luks-on-mdadm.nix
+++ b/example/luks-on-mdadm.nix
@@ -9,6 +9,7 @@
         boot = {
           size = "1M";
           type = "EF02"; # for grub MBR
+          priority = 1; # Needs to be first partition
         };
         ESP = {
           size = "500M";

--- a/example/mdadm-raid0.nix
+++ b/example/mdadm-raid0.nix
@@ -10,6 +10,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              priority = 1; # Needs to be first partition
             };
             mdadm = {
               size = "100%";
@@ -30,6 +31,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              priority = 1; # Needs to be first partition
             };
             mdadm = {
               size = "100%";

--- a/example/mdadm.nix
+++ b/example/mdadm.nix
@@ -10,6 +10,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              priority = 1; # Needs to be first partition
             };
             mdadm = {
               size = "100%";

--- a/example/with-lib.nix
+++ b/example/with-lib.nix
@@ -11,6 +11,7 @@
           boot = {
             size = "1M";
             type = "EF02";
+            priority = 1; # Needs to be first partition
           };
           root = {
             size = "100%";

--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,8 @@
         in
         {
           disko = pkgs.callPackage ./package.nix { };
-           # alias to make `nix run` more convenient
-          disko-install = self.packages.${system}.disko.overrideAttrs (old: {
+          # alias to make `nix run` more convenient
+          disko-install = self.packages.${system}.disko.overrideAttrs (_old: {
             name = "disko-install";
           });
           default = self.packages.${system}.disko;

--- a/install-cli.nix
+++ b/install-cli.nix
@@ -1,7 +1,7 @@
 { flake
 , flakeAttr
 , diskMappings
-, extraSystemConfig ? { }
+, extraSystemConfig ? "{}"
 , writeEfiBootEntries ? false
 , rootMountPoint ? "/mnt"
 ,
@@ -52,7 +52,10 @@ let
         {
           boot.loader.efi.canTouchEfiVariables = lib.mkVMOverride writeEfiBootEntries;
           boot.loader.grub.devices = lib.mkVMOverride diskoSystem.config.boot.loader.grub.devices;
-        } // extraSystemConfig
+          imports = [
+             ({ _file = "disko-install --system-config"; } // (builtins.fromJSON extraSystemConfig))
+           ];
+        }
       )
     ];
   };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -85,7 +85,7 @@ let
       else if match "/dev/mapper/.+" dev != null then
         "${dev}${toString index}" # /dev/mapper/vg-lv1 style
       else if match "/dev/loop[[:digit:]]+" dev != null
-        then "${dev}p${toString index}" # /dev/mapper/vg-lv1 style
+      then "${dev}p${toString index}" # /dev/mapper/vg-lv1 style
       else
         abort ''
           ${dev} seems not to be a supported disk format. Please add this to disko in https://github.com/nix-community/disko/blob/master/lib/default.nix
@@ -191,10 +191,10 @@ let
         isAttrsOfSubmodule = o: o.type.name == "attrsOf" && o.type.nestedTypes.elemType.name == "submodule";
         isSerializable = n: o: !(
           lib.hasPrefix "_" n
-          || lib.hasSuffix "Hook" n
-          || isAttrsOfSubmodule o
-          # TODO don't hardcode diskoLib.subType options.
-          || n == "content" || n == "partitions" || n == "datasets" || n == "swap"
+            || lib.hasSuffix "Hook" n
+            || isAttrsOfSubmodule o
+            # TODO don't hardcode diskoLib.subType options.
+            || n == "content" || n == "partitions" || n == "datasets" || n == "swap"
         );
       in
       lib.toShellVars
@@ -245,14 +245,17 @@ let
         internal = true;
         readOnly = true;
         type = diskoLib.jsonType;
-        default = lib.mapAttrsRecursive (name: value: if builtins.isString value then ''
-          (
-            ${diskoLib.indent (diskoLib.defineHookVariables { inherit options; })}
-            ${config.preMountHook}
-            ${diskoLib.indent value}
-            ${config.postMountHook}
-          )
-        '' else value) attrs.default;
+        default = lib.mapAttrsRecursive
+          (_name: value:
+            if builtins.isString value then ''
+              (
+                ${diskoLib.indent (diskoLib.defineHookVariables { inherit options; })}
+                ${config.preMountHook}
+                ${diskoLib.indent value}
+                ${config.postMountHook}
+              )
+            '' else value)
+          attrs.default;
         description = "Mount script";
       };
 

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -8,10 +8,10 @@
 }:
 let
   vmTools = pkgs.vmTools.override {
-    rootModules = ["9p" "9pnet_virtio" "virtio_pci" "virtio_blk"] ++ nixosConfig.config.disko.extraRootModules;
+    rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ] ++ nixosConfig.config.disko.extraRootModules;
     kernel = pkgs.aggregateModules
-    (with nixosConfig.config.boot.kernelPackages; [ kernel ]
-      ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);
+      (with nixosConfig.config.boot.kernelPackages; [ kernel ]
+        ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);
   };
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig nixosConfig.config diskoLib.testLib.devices;
   systemToInstall = nixosConfig.extendModules {

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -32,9 +32,9 @@ let
     lib.concatMapStringsSep
       "\n"
       (file: ''
-      if ! test -e "${mountpoint}/${file.path}"; then
-        btrfs filesystem mkswapfile --size ${file.size} "${mountpoint}/${file.path}"
-      fi
+        if ! test -e "${mountpoint}/${file.path}"; then
+          btrfs filesystem mkswapfile --size ${file.size} "${mountpoint}/${file.path}"
+        fi
       '')
       (lib.attrValues swap);
 

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -55,15 +55,17 @@ in
           };
           label = lib.mkOption {
             type = lib.types.str;
-            default = let
-              # 72 bytes is the maximum length of a GPT partition name
-              # the labels seem to be in UTF-16, so 2 bytes per character
-              limit = 36;
-              label = "${config._parent.type}-${config._parent.name}-${partition.config.name}"; 
-            in if (lib.stringLength label) > limit then
-              builtins.substring 0 limit (builtins.hashString "sha256" label)
-            else
-              label;
+            default =
+              let
+                # 72 bytes is the maximum length of a GPT partition name
+                # the labels seem to be in UTF-16, so 2 bytes per character
+                limit = 36;
+                label = "${config._parent.type}-${config._parent.name}-${partition.config.name}";
+              in
+              if (lib.stringLength label) > limit then
+                builtins.substring 0 limit (builtins.hashString "sha256" label)
+              else
+                label;
           };
           size = lib.mkOption {
             type = lib.types.either (lib.types.enum [ "100%" ]) (lib.types.strMatching "[0-9]+[KMGTP]?");
@@ -76,7 +78,7 @@ in
           };
           alignment = lib.mkOption {
             type = lib.types.int;
-            default = if (builtins.substring (builtins.stringLength partition.config.start - 1) 1 partition.config.start == "s" || (builtins.substring (builtins.stringLength partition.config.end - 1) 1 partition.config.end == "s" )) then 1 else 0;
+            default = if (builtins.substring (builtins.stringLength partition.config.start - 1) 1 partition.config.start == "s" || (builtins.substring (builtins.stringLength partition.config.end - 1) 1 partition.config.end == "s")) then 1 else 0;
             description = "Alignment of the partition, if sectors are used as start or end it can be aligned to 1";
           };
           start = lib.mkOption {
@@ -95,7 +97,7 @@ in
           };
           content = diskoLib.partitionType { parent = config; device = partition.config.device; };
           hybrid = lib.mkOption {
-            type = lib.types.nullOr (lib.types.submodule ({name, ...} @ hp: {
+            type = lib.types.nullOr (lib.types.submodule ({ ... } @ hp: {
               options = {
                 mbrPartitionType = lib.mkOption {
                   type = lib.types.nullOr lib.types.str;

--- a/lib/types/lvm_vg.nix
+++ b/lib/types/lvm_vg.nix
@@ -115,13 +115,14 @@
           (lv: [
             (lib.optional (lv.content != null) lv.content._config)
             (lib.optional (lv.lvm_type != null) {
-              boot.initrd.kernelModules = [(if lv.lvm_type == "mirror" then "dm-mirror" else "dm-raid")]
+              boot.initrd.kernelModules = [ (if lv.lvm_type == "mirror" then "dm-mirror" else "dm-raid") ]
                 ++ lib.optional (lv.lvm_type == "raid0") "raid0"
                 ++ lib.optional (lv.lvm_type == "raid1") "raid1"
                 # ++ lib.optional (lv.lvm_type == "raid10") "raid10"
-                ++ lib.optional (lv.lvm_type == "raid4" ||
-                                 lv.lvm_type == "raid5" ||
-                                 lv.lvm_type == "raid6") "raid456";
+                ++ lib.optional
+                (lv.lvm_type == "raid4" ||
+                  lv.lvm_type == "raid5" ||
+                  lv.lvm_type == "raid6") "raid456";
 
             })
           ])

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -6,155 +6,156 @@
     If you encounter errors similar to:
     "error: The option `disko.devices.disk.disk1.content.partitions."[definition 1-entry 1]".content._config` is read-only, but it's set multiple times,"
     this is likely due to the use of the legacy table type.
-  '' {
-    type = lib.mkOption {
-      type = lib.types.enum [ "table" ];
-      internal = true;
-      description = "Partition table";
-    };
-    device = lib.mkOption {
-      type = lib.types.str;
-      default = device;
-      description = "Device to partition";
-    };
-    format = lib.mkOption {
-      type = lib.types.enum [ "gpt" "msdos" ];
-      default = "gpt";
-      description = "The kind of partition table";
-    };
-    partitions = lib.mkOption {
-      type = lib.types.listOf (lib.types.submodule ({ name, ... }@partition: {
-        options = {
-          part-type = lib.mkOption {
-            type = lib.types.enum [ "primary" "logical" "extended" ];
-            default = "primary";
-            description = "Partition type";
+  ''
+    {
+      type = lib.mkOption {
+        type = lib.types.enum [ "table" ];
+        internal = true;
+        description = "Partition table";
+      };
+      device = lib.mkOption {
+        type = lib.types.str;
+        default = device;
+        description = "Device to partition";
+      };
+      format = lib.mkOption {
+        type = lib.types.enum [ "gpt" "msdos" ];
+        default = "gpt";
+        description = "The kind of partition table";
+      };
+      partitions = lib.mkOption {
+        type = lib.types.listOf (lib.types.submodule ({ name, ... }@partition: {
+          options = {
+            part-type = lib.mkOption {
+              type = lib.types.enum [ "primary" "logical" "extended" ];
+              default = "primary";
+              description = "Partition type";
+            };
+            fs-type = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "btrfs" "ext2" "ext3" "ext4" "fat16" "fat32" "hfs" "hfs+" "linux-swap" "ntfs" "reiserfs" "udf" "xfs" ]);
+              default = null;
+              description = "Filesystem type to use";
+            };
+            name = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              description = "Name of the partition";
+            };
+            start = lib.mkOption {
+              type = lib.types.str;
+              default = "0%";
+              description = "Start of the partition";
+            };
+            end = lib.mkOption {
+              type = lib.types.str;
+              default = "100%";
+              description = "End of the partition";
+            };
+            flags = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "Partition flags";
+            };
+            bootable = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether to make the partition bootable";
+            };
+            content = diskoLib.partitionType { parent = config; device = diskoLib.deviceNumbering config.device partition.config._index; };
+            _index = lib.mkOption {
+              internal = true;
+              default = lib.toInt (lib.head (builtins.match ".*entry ([[:digit:]]+)]" name));
+            };
           };
-          fs-type = lib.mkOption {
-            type = lib.types.nullOr (lib.types.enum [ "btrfs" "ext2" "ext3" "ext4" "fat16" "fat32" "hfs" "hfs+" "linux-swap" "ntfs" "reiserfs" "udf" "xfs" ]);
-            default = null;
-            description = "Filesystem type to use";
-          };
-          name = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            description = "Name of the partition";
-          };
-          start = lib.mkOption {
-            type = lib.types.str;
-            default = "0%";
-            description = "Start of the partition";
-          };
-          end = lib.mkOption {
-            type = lib.types.str;
-            default = "100%";
-            description = "End of the partition";
-          };
-          flags = lib.mkOption {
-            type = lib.types.listOf lib.types.str;
-            default = [ ];
-            description = "Partition flags";
-          };
-          bootable = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            description = "Whether to make the partition bootable";
-          };
-          content = diskoLib.partitionType { parent = config; device = diskoLib.deviceNumbering config.device partition.config._index; };
-          _index = lib.mkOption {
-            internal = true;
-            default = lib.toInt (lib.head (builtins.match ".*entry ([[:digit:]]+)]" name));
-          };
-        };
-      }));
-      default = [ ];
-      description = "List of partitions to add to the partition table";
-    };
-    _parent = lib.mkOption {
-      internal = true;
-      default = parent;
-    };
-    _meta = lib.mkOption {
-      internal = true;
-      readOnly = true;
-      type = lib.types.functionTo diskoLib.jsonType;
-      default = dev:
-        lib.foldr lib.recursiveUpdate { } (lib.imap
-          (_index: partition:
-            lib.optionalAttrs (partition.content != null) (partition.content._meta dev)
-          )
-          config.partitions);
-      description = "Metadata";
-    };
-    _create = diskoLib.mkCreateOption {
-      inherit config options;
-      default = ''
-        if ! blkid "${config.device}" >/dev/null; then
-          parted -s ${config.device} -- mklabel ${config.format}
-          ${lib.concatStrings (map (partition: ''
-            ${lib.optionalString (config.format == "gpt") ''
-              parted -s ${config.device} -- mkpart ${partition.name} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
-            ''}
-            ${lib.optionalString (config.format == "msdos") ''
-              parted -s ${config.device} -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
-            ''}
-            # ensure /dev/disk/by-path/..-partN exists before continuing
-            partprobe ${config.device}
-            udevadm trigger --subsystem-match=block
-            udevadm settle
-            ${lib.optionalString partition.bootable ''
-              parted -s ${config.device} -- set ${toString partition._index} boot on
-            ''}
-            ${lib.concatMapStringsSep "" (flag: ''
-              parted -s ${config.device} -- set ${toString partition._index} ${flag} on
-            '') partition.flags}
-            # ensure further operations can detect new partitions
-            partprobe ${config.device}
-            udevadm trigger --subsystem-match=block
-            udevadm settle
-          '') config.partitions)}
-        fi
-        ${lib.concatStrings (map (partition: ''
-          ${lib.optionalString (partition.content != null) partition.content._create}
-        '') config.partitions)}
-      '';
-    };
-    _mount = diskoLib.mkMountOption {
-      inherit config options;
-      default =
-        let
-          partMounts = lib.foldr lib.recursiveUpdate { } (map
-            (partition:
-              lib.optionalAttrs (partition.content != null) partition.content._mount
+        }));
+        default = [ ];
+        description = "List of partitions to add to the partition table";
+      };
+      _parent = lib.mkOption {
+        internal = true;
+        default = parent;
+      };
+      _meta = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = lib.types.functionTo diskoLib.jsonType;
+        default = dev:
+          lib.foldr lib.recursiveUpdate { } (lib.imap
+            (_index: partition:
+              lib.optionalAttrs (partition.content != null) (partition.content._meta dev)
             )
             config.partitions);
-        in
-        {
-          dev = partMounts.dev or "";
-          fs = partMounts.fs or { };
-        };
+        description = "Metadata";
+      };
+      _create = diskoLib.mkCreateOption {
+        inherit config options;
+        default = ''
+          if ! blkid "${config.device}" >/dev/null; then
+            parted -s ${config.device} -- mklabel ${config.format}
+            ${lib.concatStrings (map (partition: ''
+              ${lib.optionalString (config.format == "gpt") ''
+                parted -s ${config.device} -- mkpart ${partition.name} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
+              ''}
+              ${lib.optionalString (config.format == "msdos") ''
+                parted -s ${config.device} -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
+              ''}
+              # ensure /dev/disk/by-path/..-partN exists before continuing
+              partprobe ${config.device}
+              udevadm trigger --subsystem-match=block
+              udevadm settle
+              ${lib.optionalString partition.bootable ''
+                parted -s ${config.device} -- set ${toString partition._index} boot on
+              ''}
+              ${lib.concatMapStringsSep "" (flag: ''
+                parted -s ${config.device} -- set ${toString partition._index} ${flag} on
+              '') partition.flags}
+              # ensure further operations can detect new partitions
+              partprobe ${config.device}
+              udevadm trigger --subsystem-match=block
+              udevadm settle
+            '') config.partitions)}
+          fi
+          ${lib.concatStrings (map (partition: ''
+            ${lib.optionalString (partition.content != null) partition.content._create}
+          '') config.partitions)}
+        '';
+      };
+      _mount = diskoLib.mkMountOption {
+        inherit config options;
+        default =
+          let
+            partMounts = lib.foldr lib.recursiveUpdate { } (map
+              (partition:
+                lib.optionalAttrs (partition.content != null) partition.content._mount
+              )
+              config.partitions);
+          in
+          {
+            dev = partMounts.dev or "";
+            fs = partMounts.fs or { };
+          };
+      };
+      _config = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        default =
+          map
+            (partition:
+              lib.optional (partition.content != null) partition.content._config
+            )
+            config.partitions;
+        description = "NixOS configuration";
+      };
+      _pkgs = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = lib.types.functionTo (lib.types.listOf lib.types.package);
+        default = pkgs:
+          [ pkgs.parted pkgs.systemdMinimal ] ++ lib.flatten (map
+            (partition:
+              lib.optional (partition.content != null) (partition.content._pkgs pkgs)
+            )
+            config.partitions);
+        description = "Packages";
+      };
     };
-    _config = lib.mkOption {
-      internal = true;
-      readOnly = true;
-      default =
-        map
-          (partition:
-            lib.optional (partition.content != null) partition.content._config
-          )
-          config.partitions;
-      description = "NixOS configuration";
-    };
-    _pkgs = lib.mkOption {
-      internal = true;
-      readOnly = true;
-      type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs:
-        [ pkgs.parted pkgs.systemdMinimal ] ++ lib.flatten (map
-          (partition:
-            lib.optional (partition.content != null) (partition.content._pkgs pkgs)
-          )
-          config.partitions);
-      description = "Packages";
-    };
-  };
 }

--- a/lib/types/zfs_fs.nix
+++ b/lib/types/zfs_fs.nix
@@ -52,19 +52,20 @@
       description = "Metadata";
     };
 
-    _create = diskoLib.mkCreateOption {
-      inherit config options;
-      # -u prevents mounting newly created datasets, which is
-      # important to prevent accidental shadowing of mount points
-      # since (create order != mount order)
-      # -p creates parents automatically
-      default = ''
-        if ! zfs get type ${config._name} >/dev/null 2>&1; then
-          zfs create -up ${config._name} \
-            ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)}
-        fi
-      '';
-    } // { readOnly = false; };
+    _create = diskoLib.mkCreateOption
+      {
+        inherit config options;
+        # -u prevents mounting newly created datasets, which is
+        # important to prevent accidental shadowing of mount points
+        # since (create order != mount order)
+        # -p creates parents automatically
+        default = ''
+          if ! zfs get type ${config._name} >/dev/null 2>&1; then
+            zfs create -up ${config._name} \
+              ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)}
+          fi
+        '';
+      } // { readOnly = false; };
 
     _mount = diskoLib.mkMountOption {
       inherit config options;


### PR DESCRIPTION
…. Nix fmt.

I added the --system-option flag that enables a user to dynamically add system nix options. This is useful for authorized keys for example. I also added the priority flag on every EF02 partition, as else sticks wouldn't boot. Because of nix fmt more files changed then I expected sorry ^^  