### PR TITLE
Changed `disko.disks` to `disko.devices.disk`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -125,7 +125,7 @@ In the this example we create a flake containing a nixos configuration for `myho
    ```
 
    The script will generate the actual image outside of the nix store in the current working directory.
-   The create image names depend on the names used in `disko.disks` attrset in the NixOS configuration.
+   The create image names depend on the names used in `disko.devices.disk` attrset in the NixOS configuration.
    In our code example it will produce the following image:
 
    ```


### PR DESCRIPTION
In the section `### Generating the `.raw` VM Image` in step 3. It is written that the raw image file created is named `vdb`, but in the file [simple-efi.nix](https://github.com/nix-community/disko/blob/a816daa384dd754b7586f51157fc2e1a44e76073/example/simple-efi.nix) the first time `vdb` is mentioned is in `disko.devices.disk` not in `disko.disks` so I assumed that the file [simple-efi.nix](https://github.com/nix-community/disko/blob/a816daa384dd754b7586f51157fc2e1a44e76073/example/simple-efi.nix) was updated it the part about `disko.disks` is a mistake. Otherwise, I would really like to know what I am not understanding here :grin: