### PR TITLE
swap: support swapDevices' discardPolicy and priority options

### DIFF
--- a/example/swap.nix
+++ b/example/swap.nix
@@ -35,6 +35,7 @@
               size = "100%";
               content = {
                 type = "swap";
+                discardPolicy = "both";
                 resumeDevice = true; # resume from hiberation from this device
               };
             };

--- a/example/swap.nix
+++ b/example/swap.nix
@@ -29,6 +29,7 @@
               content = {
                 type = "swap";
                 randomEncryption = true;
+                priority = 100; # prefer to encrypt as long as we have space for it
               };
             };
             plainSwap = {

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -11,6 +11,18 @@
       default = device;
       description = "Device";
     };
+    discardPolicy = lib.mkOption {
+      default = null;
+      example = "once";
+      type = lib.types.nullOr (lib.types.enum [ "once" "pages" "both" ]);
+      description = lib.mdDoc ''
+        Specify the discard policy for the swap device. If "once", then the
+        whole swap space is discarded at swapon invocation. If "pages",
+        asynchronous discard on freed pages is performed, before returning to
+        the available pages pool. With "both", both policies are activated.
+        See swapon(8) for more information.
+      '';
+    };
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -53,7 +65,11 @@
       default = lib.optionalAttrs (!config.randomEncryption) {
         fs.${config.device} = ''
           if ! swapon --show | grep -q "^$(readlink -f ${config.device}) "; then
-            swapon ${config.device}
+            swapon ${
+              lib.optionalString (config.discardPolicy != null)
+                "--discard${lib.optionalString (config.discardPolicy != "both")
+                "=${config.discardPolicy}"
+              }"} ${config.device}
           fi
         '';
       };
@@ -64,7 +80,7 @@
       default = [{
         swapDevices = [{
           device = config.device;
-          randomEncryption = config.randomEncryption;
+          inherit (config) discardPolicy randomEncryption;
         }];
         boot.resumeDevice = lib.mkIf config.resumeDevice config.device;
       }];

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -28,6 +28,15 @@
       default = [ ];
       description = "Extra arguments";
     };
+    priority = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = lib.mdDoc ''
+        Specify the priority of the swap device. Priority is a value between 0 and 32767.
+        Higher numbers indicate higher priority.
+        null lets the kernel choose a priority, which will show up as a negative value.
+      '';
+    };
     randomEncryption = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -69,7 +78,10 @@
               lib.optionalString (config.discardPolicy != null)
                 "--discard${lib.optionalString (config.discardPolicy != "both")
                 "=${config.discardPolicy}"
-              }"} ${config.device}
+              }"} ${
+              lib.optionalString (config.priority != null)
+                "--priority=${toString config.priority}"
+              } ${config.device}
           fi
         '';
       };
@@ -80,7 +92,7 @@
       default = [{
         swapDevices = [{
           device = config.device;
-          inherit (config) discardPolicy randomEncryption;
+          inherit (config) discardPolicy priority randomEncryption;
         }];
         boot.resumeDevice = lib.mkIf config.resumeDevice config.device;
       }];


### PR DESCRIPTION
This just forwards to the underlying NixOS options and expands the mount
script to exhibit the same behavior.