### PR TITLE
swap: forward discardPolicy option to randomEncryption.allowDiscards

### DIFF
--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -92,7 +92,12 @@
       default = [{
         swapDevices = [{
           device = config.device;
-          inherit (config) discardPolicy priority randomEncryption;
+          inherit (config) discardPolicy priority;
+          randomEncryption = {
+            enable = config.randomEncryption;
+            # forward discard/TRIM attempts through dm-crypt
+            allowDiscards = config.discardPolicy != null;
+          };
         }];
         boot.resumeDevice = lib.mkIf config.resumeDevice config.device;
       }];


### PR DESCRIPTION
I.e. instead of effectively ignoring `discardPolicy` when combined with `randomEncryption`, or adding a second option requiring the user to repeat themselves (DRY violation), just enable both when requested via `discardPolicy`.

Without this `discardPolicy` is a NOP when `randomEncryption` is enabled.

Follow-up: #623