### PR TITLE
Add missing dependencies

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -385,8 +385,9 @@ let
             internal = true;
             description = ''
               packages required by the disko configuration
+              coreutils is always included
             '';
-            default = pkgs: unique (flatten (map (dev: dev._pkgs pkgs) (flatten (map attrValues (attrValues devices)))));
+            default = pkgs: unique ((flatten (map (dev: dev._pkgs pkgs) (flatten (map attrValues (attrValues devices))))) ++ [ pkgs.coreutils-full ]);
           };
           _scripts = lib.mkOption {
             internal = true;
@@ -405,6 +406,7 @@ let
                   jq
                   gnused
                   gawk
+                  coreutils-full
                 ])}:$PATH
                 ${cfg.config._destroy}
               '';

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -219,7 +219,7 @@ in
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
       default = pkgs:
-        [ pkgs.btrfs-progs pkgs.coreutils pkgs.gnugrep ];
+        [ pkgs.btrfs-progs pkgs.gnugrep ];
       description = "Packages";
     };
   };


### PR DESCRIPTION
This allows for the disko scripts to be ran in more foreign environments where we can't assume the basic utilities coreutils provides are available or aren't 1-for-1 compatible (e.g. busybox utilities).