### PR TITLE
make-disk-image: make extraPostVM configurable from module.nix

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -3,7 +3,7 @@
 , pkgs ? nixosConfig.pkgs
 , lib ? pkgs.lib
 , name ? "${nixosConfig.config.networking.hostName}-disko-images"
-, extraPostVM ? ""
+, extraPostVM ? nixosConfig.config.disko.extraPostVM
 , checked ? false
 }:
 let

--- a/module.nix
+++ b/module.nix
@@ -17,6 +17,17 @@ in
       '';
       default = [ ];
     };
+    extraPostVM = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        extra shell code to execute once the disk image(s) have been succesfully created and moved to $out
+      '';
+      default = "";
+      example = pkgs.literalExpression ''
+        ''${pkgs.zstd}/bin/zstd --compress $out/*raw
+        rm $out/*raw
+      '';
+    };
     memSize = lib.mkOption {
       type = lib.types.int;
       description = ''


### PR DESCRIPTION
My use case was compressing disk images, like this:

```nix
  disko.extraPostVM = ''
    ${pkgs.zstd}/bin/zstd --compress $out/*raw
    rm $out/*raw
  '';
```