### PR TITLE
make-disk-image: use OVMF efi always

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -73,7 +73,8 @@ let
     ${systemToInstall.config.system.build.nixos-install}/bin/nixos-install --root ${systemToInstall.config.disko.rootMountPoint} --system ${systemToInstall.config.system.build.toplevel} --keep-going --no-channel-copy -v --no-root-password --option binary-caches ""
     umount -Rv ${systemToInstall.config.disko.rootMountPoint}
   '';
-  QEMU_OPTS = lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report,format=raw") (lib.attrValues nixosConfig.config.disko.devices.disk);
+
+  QEMU_OPTS = "-drive if=pflash,format=raw,unit=0,readonly=on,file=${pkgs.OVMF.firmware}" + " " + (lib.concatMapStringsSep " " (disk: "-drive file=${disk.name}.raw,if=virtio,cache=unsafe,werror=report,format=raw") (lib.attrValues nixosConfig.config.disko.devices.disk));
 in
 {
   pure = vmTools.runInLinuxVM (pkgs.runCommand name


### PR DESCRIPTION
When building disk images, the VM used to perform partitioning/mkfs inherits the kernel from the nixosConfiguration we're trying to build for. This works fine, until you try to boot a kernel with `zboot`, and in that case you need UEFI to load the image, otherwise you end up with the following log from QEMU:

"unable to handle EFI zboot image with ... compression"

https://github.com/qemu/qemu/blob/master/hw/core/loader.c#L924

Loading OVMF allows us to bypass this issue, and boot the kernel successfully like this:

```
corpo-disko-images> UEFI firmware (version  built at 00:00:00 on Jan  1 1980)
corpo-disko-images> EFI stub: Decompressing Linux Kernel...
corpo-disko-images> EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path
corpo-disko-images> EFI stub: Generating empty DTB
corpo-disko-images> EFI stub: Exiting boot services...
corpo-disko-images> loading kernel modules...
```

I think the architecture of inheriting the host kernel just to make a disk image from a nixosConfiguration might still be a bit wrong. But this PR fixes the issue for the time being. 