### PR TITLE
lvm_vg: add lvm thinpool/thinlv support 

### DIFF
--- a/example/lvm-thin.nix
+++ b/example/lvm-thin.nix
@@ -1,0 +1,71 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        type = "disk";
+        device = "/dev/vdb";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "500M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [
+                  "defaults"
+                ];
+              };
+            };
+            primary = {
+              size = "100%";
+              content = {
+                type = "lvm_pv";
+                vg = "mainpool";
+              };
+            };
+          };
+        };
+      };
+    };
+    lvm_vg = {
+      mainpool = {
+        type = "lvm_vg";
+        lvs = {
+          thinpool = {
+            size = "100M";
+            lvm_type = "thin-pool";
+          };
+          root = {
+            size = "10M";
+            lvm_type = "thinlv";
+            pool = "thinpool";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/";
+              mountOptions = [
+                "defaults"
+              ];
+            };
+          };
+          home = {
+            size = "10M";
+            lvm_type = "thinlv";
+            pool = "thinpool";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/home";
+            };
+          };
+          raw = {
+            size = "10M";
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/lvm-thin.nix
+++ b/tests/lvm-thin.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "lvm-thin";
+  disko-config = ../example/lvm-thin.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /home");
+  '';
+}


### PR DESCRIPTION
This is #285 rebased with some changes to priority.

- Device mapper kernel modules are loaded based on the LV types used. This applies to all types of LVs (mirror, raid, etc.) that have loadable modules.
- New types for the containing "thin-pool" and nested "thinlv".
- Thin pools have a lower priority than other LVs so that they are created first.
- Example and tests for a setup with thin pool and thin LVs


