### PR TITLE
gpt: move boot partitions to the front of disko

### DIFF
--- a/example/boot-raid1.nix
+++ b/example/boot-raid1.nix
@@ -38,7 +38,6 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
-              priority = 1; # Needs to be first partition
             };
             ESP = {
               size = "500M";

--- a/example/gpt-bios-compat.nix
+++ b/example/gpt-bios-compat.nix
@@ -11,7 +11,6 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
-              priority = 1; # Needs to be first partition
             };
             root = {
               size = "100%";

--- a/example/hybrid-tmpfs-on-root.nix
+++ b/example/hybrid-tmpfs-on-root.nix
@@ -9,7 +9,6 @@
           boot = {
             size = "1M";
             type = "EF02"; # for grub MBR
-            priority = 1; # Needs to be first partition
           };
           ESP = {
             name = "ESP";

--- a/example/hybrid.nix
+++ b/example/hybrid.nix
@@ -10,7 +10,6 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
-              priority = 1; # Needs to be first partition
             };
             ESP = {
               size = "512M";

--- a/example/luks-on-mdadm.nix
+++ b/example/luks-on-mdadm.nix
@@ -9,7 +9,6 @@
         boot = {
           size = "1M";
           type = "EF02"; # for grub MBR
-          priority = 1; # Needs to be first partition
         };
         ESP = {
           size = "500M";

--- a/example/mdadm-raid0.nix
+++ b/example/mdadm-raid0.nix
@@ -10,7 +10,6 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
-              priority = 1; # Needs to be first partition
             };
             mdadm = {
               size = "100%";
@@ -31,7 +30,6 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
-              priority = 1; # Needs to be first partition
             };
             mdadm = {
               size = "100%";

--- a/example/mdadm.nix
+++ b/example/mdadm.nix
@@ -10,7 +10,6 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
-              priority = 1; # Needs to be first partition
             };
             mdadm = {
               size = "100%";

--- a/example/with-lib.nix
+++ b/example/with-lib.nix
@@ -11,7 +11,6 @@
           boot = {
             size = "1M";
             type = "EF02";
-            priority = 1; # Needs to be first partition
           };
           root = {
             size = "100%";

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -45,7 +45,19 @@ in
           };
           priority = lib.mkOption {
             type = lib.types.int;
-            default = if (partition.config.size or "" == "100%") then 9001 else 1000;
+            default = if partition.config.size or "" == "100%" then
+              9001
+            else if partition.config.type == "EF02" then
+              # Boot partition should be created first, because some BIOS implementations require it.
+              # Priority defaults to 100 here to support any potential use-case for placing partitions prior to EF02
+              100
+            else
+              1000;
+            defaultText = ''
+              1000: normal partitions
+              9001: partitions with 100% size
+              100: boot partitions (EF02)
+            '';
             description = "Priority of the partition, smaller values are created first";
           };
           name = lib.mkOption {


### PR DESCRIPTION
Than we no longer need to do this in our examples.