### PR TITLE
zfs: try to import zpool in incremental mode

### DIFF
--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -62,7 +62,9 @@
       inherit config options;
       default = ''
         readarray -t zfs_devices < <(cat "$disko_devices_dir"/zfs_${config.name})
-        if zpool list '${config.name}'; then
+        # Try importing the pool without mounting anything if it exists.
+        # This allows us to set mounpoints.
+        if zpool import -N -f '${config.name}' || zpool list '${config.name}'; then
           echo "not creating zpool ${config.name} as a pool with that name already exists" >&2
         else
           continue=1


### PR DESCRIPTION
if the pool is not imported, zfs list will return a value. So to check that the pool does not exist, we also import it.

fixes https://github.com/nix-community/disko/issues/690