### PR TITLE
make-disk-image: make pkgs, qemu and kernelPackages configurable and overridable

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -9,6 +9,7 @@
 let
   vmTools = pkgs.vmTools.override {
     rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ] ++ nixosConfig.config.disko.extraRootModules;
+    customQemu = nixosConfig.config.disko.imageBuilderQemu;
     kernel = pkgs.aggregateModules
       (with nixosConfig.config.disko.imageBuilderKernelPackages; [ kernel ]
         ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -10,7 +10,7 @@ let
   vmTools = pkgs.vmTools.override {
     rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ] ++ nixosConfig.config.disko.extraRootModules;
     kernel = pkgs.aggregateModules
-      (with nixosConfig.config.boot.kernelPackages; [ kernel ]
+      (with nixosConfig.config.disko.imageBuilderKernelPackages; [ kernel ]
         ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);
   };
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig nixosConfig.config diskoLib.testLib.devices;

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -1,6 +1,6 @@
 { nixosConfig
 , diskoLib
-, pkgs ? nixosConfig.pkgs
+, pkgs ? nixosConfig.config.disko.imageBuilderPkgs
 , lib ? pkgs.lib
 , name ? "${nixosConfig.config.networking.hostName}-disko-images"
 , extraPostVM ? nixosConfig.config.disko.extraPostVM

--- a/module.nix
+++ b/module.nix
@@ -10,8 +10,16 @@ let
 in
 {
   options.disko = {
-    imageBuilderKernel = lib.mkOption {
-      type = lib.types.package;
+    imageBuilderQemu = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      description = ''
+        the qemu emulator string used when building disk images via make-disk-image.nix.
+        Useful when using binfmt on your build host, and wanting to build disk
+        images for a foreign architecture
+      '';
+      default = null;
+      example = lib.literalExpression "''${pkgs.qemu_kvm}/bin/qemu-system-aarch64";
+    };
     imageBuilderPkgs = lib.mkOption {
       type = lib.types.attrs;
       description = ''

--- a/module.nix
+++ b/module.nix
@@ -12,6 +12,15 @@ in
   options.disko = {
     imageBuilderKernel = lib.mkOption {
       type = lib.types.package;
+    imageBuilderPkgs = lib.mkOption {
+      type = lib.types.attrs;
+      description = ''
+        the pkgs instance used when building disk images via make-disk-image.nix.
+        Useful when the config's kernel won't boot in the image-builder.
+      '';
+      default = pkgs;
+      example = lib.literalExpression "pkgs";
+    };
     imageBuilderKernelPackages = lib.mkOption {
       type = lib.types.attrs;
       description = ''

--- a/module.nix
+++ b/module.nix
@@ -10,6 +10,17 @@ let
 in
 {
   options.disko = {
+    imageBuilderKernel = lib.mkOption {
+      type = lib.types.package;
+    imageBuilderKernelPackages = lib.mkOption {
+      type = lib.types.attrs;
+      description = ''
+        the kernel used when building disk images via make-disk-image.nix.
+        Useful when the config's kernel won't boot in the image-builder.
+      '';
+      default = config.boot.kernelPackages;
+      example = lib.literalExpression "pkgs.linuxPackages_testing";
+    };
     extraRootModules = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       description = ''


### PR DESCRIPTION
I have found this is very necessary when trying to build images for embedded devices like raspberry pi's, in summary:

- make-disk-image: allow vmTools qemu usage to be overriden by disko configuration
  This is needed to prevent two layers of emulation when offering a build for a host running binfmt such as an x86 host trying to compile for aarch64 via binfmt

- make-disk-image: allow pkgs to be overriden by disko configuration
  This is needed when the nixosConfig you're building for modifies nixpkgs options that lead to evaluation failing unnecessarily

- make-disk-image: allow kernel to be overriden by disko configuration
  This is especially useful when trying to build images for embedded systems such as the pi, which have a vendor kernel that can't be booted as part of the disko image builder process

This PR requires https://github.com/NixOS/nixpkgs/pull/325619 to be merged first, or a better approach to be found.