### PR TITLE
disko: add nixos-install-tools to PATH

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, makeWrapper, lib, path, nix, coreutils }:
+{ stdenvNoCC, makeWrapper, lib, path, nix, coreutils, nixos-install-tools }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   name = "disko";
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       sed -e "s|libexec_dir=\".*\"|libexec_dir=\"$out/share/disko\"|" "$i" > "$out/bin/$i"
       chmod 755 "$out/bin/$i"
       wrapProgram "$out/bin/$i" \
-        --prefix PATH : ${lib.makeBinPath [ nix coreutils ]} \
+        --prefix PATH : ${lib.makeBinPath [ nix coreutils nixos-install-tools ]} \
         --prefix NIX_PATH : "nixpkgs=${path}"
     done
   '';


### PR DESCRIPTION
When running disko-install from a distribution that is not NixOS, the nixos-install command was failing due to nixos-install not being in PATH.

Fix the error by adding the nixos-install-tools package to the list of packages passed to lib.makeBinPath.

Fixes #711.