### PR TITLE
Add --check option to formatter in flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ recursive layouts.
 Disko doesn't require installation: it can be run directly from nix-community
 repository. The [Quickstart Guide](./docs/quickstart.md) documents how to run
 Disko in its simplest form when installing NixOS. Alternatively, you can also
-use the new [disko-install](./docs/disko-install.md) tool, which combines `disko` and `nixos-install` into one step.
+use the new [disko-install](./docs/disko-install.md) tool, which combines
+`disko` and `nixos-install` into one step.
 
 For information on other use cases, including upgrading from an older version of
 **disko**, using **disko** without NixOS and downloading the module, see the

--- a/docs/interactive-vm.md
+++ b/docs/interactive-vm.md
@@ -1,7 +1,9 @@
 # Running Interactive VMs with disko
 
-disko now exports its own flavor of interactive VMs (similiar to config.system.build.vm).
-Simply import the disko module and build the vm runner with:
+disko now exports its own flavor of interactive VMs (similiar to
+config.system.build.vm). Simply import the disko module and build the vm runner
+with:
+
 ```
 nix build -L '.#nixosConfigurations.mymachine.config.system.build.vmWithDisko'
 ```
@@ -12,7 +14,8 @@ afterwards you can run the interactive VM with:
 result/bin/disko-vm
 ```
 
-You can configure the VM using the `virtualisation.vmVariantWithDisko` NixOS option:
+You can configure the VM using the `virtualisation.vmVariantWithDisko` NixOS
+option:
 
 ```nix
 {
@@ -24,6 +27,6 @@ You can configure the VM using the `virtualisation.vmVariantWithDisko` NixOS opt
 }
 ```
 
-extraConfig that is set in disko.tests.extraConfig is also applied to the interactive VMs.
-imageSize of the VMs will be determined by the imageSize in the disk type in your disko config.
-memorySize is set by disko.memSize
+extraConfig that is set in disko.tests.extraConfig is also applied to the
+interactive VMs. imageSize of the VMs will be determined by the imageSize in the
+disk type in your disko config. memorySize is set by disko.memSize

--- a/flake.nix
+++ b/flake.nix
@@ -85,10 +85,58 @@
             deadnix
           ];
           text = ''
-            set -o xtrace
-            nixpkgs-fmt "$@"
-            deno fmt "$@"
-            deadnix --edit "$@"
+            showUsage() {
+              cat <<EOF
+            Usage: $0 [OPTIONS] FILES...
+              -c, --check  Only check formatting, do not modify files.
+              -h, --help   Show this help message.
+            EOF
+            }
+
+            check=
+            files=()
+
+            parseArgs() {
+              while [[ $# -gt 0 ]]; do
+                case "$1" in
+                -h | --help)
+                  showUsage
+                  exit 0
+                  ;;
+                -c | --check)
+                  check=1
+                  ;;
+                *)
+                  files+=("$1")
+                  ;;
+                esac
+                shift
+              done
+
+              if [[ ''${#files[@]} -eq 0 ]]; then
+                files=(.)
+              fi
+            }
+
+            main() {
+              parseArgs "$@"
+
+              if [[ -z "$check" ]]; then
+                set -o xtrace
+
+                nixpkgs-fmt -- "''${files[@]}"
+                deno fmt -- "''${files[@]}"
+                deadnix --edit -- "''${files[@]}"
+              else
+                set -o xtrace
+
+                nixpkgs-fmt --check -- "''${files[@]}"
+                deno fmt --check -- "''${files[@]}"
+                deadnix -- "''${files[@]}"
+              fi
+            }
+
+            main "$@"
           '';
         }
       );

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -31,7 +31,7 @@ in
           types = {
             topology =
               let
-                vdev = lib.types.submodule ({ name, ... }: {
+                vdev = lib.types.submodule ({ ... }: {
                   options = {
                     mode = lib.mkOption {
                       type = lib.types.enum modeOptions;
@@ -44,10 +44,9 @@ in
                     };
                   };
                 });
-                parent = config;
               in
               lib.types.submodule
-                ({ config, name, ... }: {
+                ({ ... }: {
                   options = {
                     type = lib.mkOption {
                       type = lib.types.enum [ "topology" ];

--- a/module.nix
+++ b/module.nix
@@ -189,7 +189,7 @@ in
       Machine configuration to be added for the vm script available at `.system.build.vmWithDisko`.
     '';
     inherit (vmVariantWithDisko) type;
-    default = {};
+    default = { };
     visible = "shallow";
   };
 

--- a/package.nix
+++ b/package.nix
@@ -33,4 +33,5 @@ let
       mainProgram = finalAttrs.name;
     };
   });
-in self
+in
+self

--- a/tests/standalone.nix
+++ b/tests/standalone.nix
@@ -1,6 +1,4 @@
-{ pkgs ? import <nixpkgs> { }
-, diskoLib ? pkgs.callPackage ../lib { }
-}:
+{ pkgs ? import <nixpkgs> { }, ... }:
 (pkgs.nixos [
   ../example/stand-alone/configuration.nix
   { documentation.enable = false; }


### PR DESCRIPTION
I noticed that master is not formatted properly. Would it be interesting to add a CI check for formatting? This PR adds an option to `nix fmt` to check formatting without modifying files which could be added to buildbot.