### PR TITLE
refac(examples): Denest the source

### DIFF
--- a/example/legacy-table.nix
+++ b/example/legacy-table.nix
@@ -1,40 +1,38 @@
 {
-  disko.devices = {
-    disk = {
-      main = {
-        device = "/dev/sda";
-        type = "disk";
-        content = {
-          type = "table";
-          format = "gpt";
-          partitions = [
-            {
-              name = "ESP";
-              start = "1M";
-              end = "500M";
-              bootable = true;
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = "/boot";
-              };
-            }
-            {
-              name = "root";
-              start = "500M";
-              end = "100%";
-              part-type = "primary";
-              bootable = true;
-              content = {
-                type = "filesystem";
-                format = "ext4";
-                mountpoint = "/";
-              };
-            }
-          ];
-        };
-      };
-    };
+  disko.devices.disk.main = {
+    device = "/dev/sda";
+    type = "disk";
   };
+
+  disko.devices.disk.main.content = {
+    type = "table";
+    format = "gpt";
+  };
+
+  disko.devices.disk.main.content.partitions = [
+    {
+      name = "ESP";
+      start = "1M";
+      end = "500M";
+      bootable = true;
+      content = {
+        type = "filesystem";
+        format = "vfat";
+        mountpoint = "/boot";
+      };
+    }
+    {
+      name = "root";
+      start = "500M";
+      end = "100%";
+      part-type = "primary";
+      bootable = true;
+      content = {
+        type = "filesystem";
+        format = "ext4";
+        mountpoint = "/";
+      };
+    }
+  ];
 }
 


### PR DESCRIPTION
Hi!

I was just trying to understand the `disko`'s examples, and i did this refactoring.

i found this interesting and thought to share with yous and ask if you'd be interested to get a merge request  refactoring others in a similar fashion too :smiley:?


![image](https://github.com/user-attachments/assets/188d67e9-06da-499f-a8fa-30ff35de4d3d)


----
[nixel reference]: https://nix.dev/tutorials/nix-language.html#evaluating-nix-files "Evaluating Nix files"

i tried to run the `nix-instantiate --eval --strict` ([nixel reference]) and yes, these evaluated to absolutely same thing :smiley:  

```console
$ nix-instantiate --eval --strict legacy-table.nix
{ disko = { devices = { disk = { main = { content = { format = "gpt"; partitions = [ { bootable = true; content = { format = "vfat"; mountpoint = "/boot"; type = "filesystem"; }; end = "500M"; name = "ESP"; start = "1M"; } { bootable = true; content = { format = "ext4"; mountpoint = "/"; type = "filesystem"; }; end = "100%"; name = "root"; part-type = "primary"; start = "500M"; } ]; type = "table"; }; device = "/dev/sda"; type = "disk"; }; }; }; }; }

$ nix-instantiate --eval --strict legacy-table-refactored.nix 
{ disko = { devices = { disk = { main = { content = { format = "gpt"; partitions = [ { bootable = true; content = { format = "vfat"; mountpoint = "/boot"; type = "filesystem"; }; end = "500M"; name = "ESP"; start = "1M"; } { bootable = true; content = { format = "ext4"; mountpoint = "/"; type = "filesystem"; }; end = "100%"; name = "root"; part-type = "primary"; start = "500M"; } ]; type = "table"; }; device = "/dev/sda"; type = "disk"; }; }; }; }; }

```

----
a more elaborate setup to compare automated-ly, rather than eyeballing :eyes: :

```bash
eval-diff() {
  # Show diff of strict-eval of 2 nix files

  # Get the parameters
  local oldfile=$1
  local newfile=$2

  # Function: Abstract out the flags in invocation
  sevalnix() { nix-instantiate --eval --strict $1; }

  # Strict-evaluate both the files
  local oldval="$(sevalnix ${oldfile})"
  local newval="$(sevalnix ${newfile})"

  # Use process substitution to make stdout act as files to `diff` utility
  diff -u <(echo "$oldval") <(echo "$newval") | 

  # Pipe to `bat` with syntax-highlighting for diff
  bat -l diff;
}
```

```console
$ eval-diff legacy-table{,-refactored}.nix 
───────┬──────────────────────────────────────────────────────────────
       │ STDIN   <EMPTY>
───────┴──────────────────────────────────────────────────────────────


```