### PR TITLE
Lib: vmtools use default linux pkgs.

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -10,7 +10,7 @@ let
   vmTools = pkgs.vmTools.override {
     rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ] ++ nixosConfig.config.disko.extraRootModules;
     kernel = pkgs.aggregateModules
-      (with nixosConfig.config.boot.kernelPackages; [ kernel ]
+      (with pkgs.linuxPackages; [ kernel ]
         ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);
   };
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig nixosConfig.config diskoLib.testLib.devices;


### PR DESCRIPTION
When building diskoImage in Qemu with a custom kernel (nixosConfig.config.boot.kernelPackages) which does not have kernel modules in ["9p" "9pnet_virtio" "virtio_pci" "virtio_blk"]. 
The build process will raise a module not found error.
Just use nixpkgs default kernel instead.