### PR TITLE
Fix options.json rendering

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -36,6 +36,7 @@ in
         Useful when the config's kernel won't boot in the image-builder.
       '';
       default = config.boot.kernelPackages;
+      defaultText = lib.literalExpression "config.boot.kernelPackages";
       example = lib.literalExpression "pkgs.linuxPackages_testing";
     };
     extraRootModules = lib.mkOption {


### PR DESCRIPTION
error I got before:

```
… while evaluating the default value of option `disko.imageBuilderKernelPackages`

(stack trace truncated; use '--show-trace' to show the full, detailed trace)

error: attribute 'boot' missing
at /nix/store/g1sd9vgb758mb00vqxcnl9g01f0xgyfb-source/module.nix:38:17:
37|       '';
38|       default = config.boot.kernelPackages;
|                 ^
39|       example = lib.literalExpression "pkgs.linuxPackages_testing";
```