### PR TITLE
swap: don't create filesystem if randomEncryption is enabled

### DIFF
--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -60,7 +60,8 @@
     };
     _create = diskoLib.mkCreateOption {
       inherit config options;
-      default = ''
+      # TODO: we don't support encrypted swap yet
+      default = lib.optionalString (!config.randomEncryption) ''
         if ! blkid "${config.device}" -o export | grep -q '^TYPE='; then
           mkswap \
             ${toString config.extraArgs} \


### PR DESCRIPTION
This is not an issue when initially creating the partition because device mapper will just map on top of the filesystem, but it breaks incremental updates because the check for `TYPE=` will fail, and the subsequent attempt to run `mkswap` also fails:

```
mkswap: cannot open /dev/disk/by-partlabel/disk-nix-store-swap: Device or resource busy
```

Instead, just don't do anything, NixOS will take care of it.

This is basically the same as #455 