### PR TITLE
swap: mountOptions; btrfs priority, options

### DIFF
--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -13,6 +13,23 @@ let
           default = name;
           description = "Path to the swap file (relative to the mountpoint)";
         };
+
+        priority = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = lib.mdDoc ''
+            Specify the priority of the swap file. Priority is a value between 0 and 32767.
+            Higher numbers indicate higher priority.
+            null lets the kernel choose a priority, which will show up as a negative value.
+          '';
+        };
+
+        options = lib.mkOption {
+          type = lib.types.listOf lib.types.nonEmptyStr;
+          default = [ "defaults" ];
+          example = [ "nofail" ];
+          description = "Options used to mount the swap.";
+        };
       };
     }));
     default = { };
@@ -24,6 +41,7 @@ let
       swapDevices = builtins.map
         (file: {
           device = "${mountpoint}/${file.path}";
+          inherit (file) priority options;
         })
         (lib.attrValues swap);
     };

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -28,6 +28,12 @@
       default = [ ];
       description = "Extra arguments";
     };
+    mountOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.nonEmptyStr;
+      default = [ "defaults" ];
+      example = [ "nofail" ];
+      description = "Options used to mount the swap.";
+    };
     priority = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
       default = null;
@@ -82,7 +88,9 @@
               }"} ${
               lib.optionalString (config.priority != null)
                 "--priority=${toString config.priority}"
-              } ${config.device}
+              } \
+              --options=${lib.concatStringsSep "," config.mountOptions} \
+              ${config.device}
           fi
         '';
       };
@@ -99,6 +107,7 @@
             # forward discard/TRIM attempts through dm-crypt
             allowDiscards = config.discardPolicy != null;
           };
+          options = config.mountOptions;
         }];
         boot.resumeDevice = lib.mkIf config.resumeDevice config.device;
       }];


### PR DESCRIPTION
Add missing configuration options for regular (types/swap) and btrfs (types/btrfs) swap.

-  `types/swap`: `mountOptions`
   - will allow specifying such options as `nofail` which is currently not possible
   - named to be consistent with `mountOptions` for other fs types
   - relevant mount script changes

- `types/btrfs`:
  - `priority` and `options`
  - naming consistent with underlying nixos options
