### PR TITLE
Switch to qcow in the interactive VM to avoid hangs when using large image size.

### DIFF
--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -30,6 +30,7 @@ let
       disko.devices = cfg_.disko.devices;
     };
     testMode = true;
+    imageFormat = "qcow2";
   };
   rootDisk = {
     name = "root";
@@ -79,8 +80,8 @@ in
     trap 'rm -rf "$tmp"' EXIT
     ${lib.concatMapStringsSep "\n" (disk: ''
       ${pkgs.qemu}/bin/qemu-img create -f qcow2 \
-      -b ${diskoImages}/${disk.name}.raw \
-      -F raw "$tmp"/${disk.name}.qcow2
+      -b ${diskoImages}/${disk.name}.qcow2 \
+      -F qcow2 "$tmp"/${disk.name}.qcow2
     '') disks}
     set +f
     ${vm}/bin/run-*-vm

--- a/lib/types/disk.nix
+++ b/lib/types/disk.nix
@@ -20,7 +20,7 @@
       type = lib.types.strMatching "[0-9]+[KMGTP]?";
       description = ''
         size of the image if the makeDiskImages function from diksoLib is used.
-        is used as an argument to truncate -s
+        is used as an argument to "qemu-img create ..."
       '';
       default = "2G";
     };


### PR DESCRIPTION
When using large image size (1TB for example), vmWithDisko hangs, this PR changes image format to qcow2 to resolve hanging issue.