### PR TITLE
make-disk-image: remove customQemu.

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -13,7 +13,6 @@
 let
   vmTools = pkgs.vmTools.override {
     rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ] ++ nixosConfig.config.disko.extraRootModules;
-    customQemu = nixosConfig.config.disko.imageBuilderQemu;
     kernel = pkgs.aggregateModules
       (with nixosConfig.config.disko.imageBuilderKernelPackages; [ kernel ]
         ++ lib.optional (lib.elem "zfs" nixosConfig.config.disko.extraRootModules) zfs);

--- a/module.nix
+++ b/module.nix
@@ -10,16 +10,6 @@ let
 in
 {
   options.disko = {
-    imageBuilderQemu = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      description = ''
-        the qemu emulator string used when building disk images via make-disk-image.nix.
-        Useful when using binfmt on your build host, and wanting to build disk
-        images for a foreign architecture
-      '';
-      default = null;
-      example = lib.literalExpression "\${pkgs.qemu_kvm}/bin/qemu-system-aarch64";
-    };
     imageBuilderPkgs = lib.mkOption {
       type = lib.types.attrs;
       description = ''


### PR DESCRIPTION
Fix https://github.com/nix-community/disko/issues/758. 
Latest nixpkgs unstable branch has removed the
customQemu arg in calling vmtools.
This commit removes the customQemu arg and the
imageBuilderQemu option.