### PR TITLE
zfs_fs: support updating mountpoint properly

### DIFF
--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -253,7 +253,7 @@ in
   config = {
     datasets."__root" = {
       _name = config.name;
-      _create = "";
+      _createFilesystem = false;
       type = "zfs_fs";
       mountpoint = config.mountpoint;
       options = config.rootFsOptions;


### PR DESCRIPTION
Use `zfs set -u` to update the `mountpoint` flag without mounting or unmounting the filesystem. This flag was added in OpenZFS 2.2.0, which was released October 2023.

The previous logic would not update `mountpoint` if `config.options` was empty or only contained `mountpoint`.