### PR TITLE
Add `virtualisation.vmVariantWithDisko` option

### DIFF
--- a/docs/interactive-vm.md
+++ b/docs/interactive-vm.md
@@ -12,6 +12,16 @@ afterwards you can run the interactive VM with:
 result/bin/disko-vm
 ```
 
+You can configure the VM using the `virtualisation.vmVariantWithDisko` NixOS option:
+
+```nix
+{
+  virtualisation.vmVariantWithDisko = {
+    virtualisation.fileSystems."/persist".neededForBoot = true;
+  };
+}
+```
+
 extraConfig that is set in disko.tests.extraConfig is also applied to the interactive VMs.
 imageSize of the VMs will be determined by the imageSize in the disk type in your disko config.
 memorySize is set by disko.memSize

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -16,8 +16,6 @@ let
     # a version of makeDiskImage which runs outside of the store
     makeDiskImagesScript = args: (import ./make-disk-image.nix ({ inherit diskoLib; } // args)).impure;
 
-    makeVMRunner = args: import ./interactive-vm.nix ({ inherit diskoLib; } // args);
-
     testLib = import ./tests.nix { inherit lib makeTest eval-config; };
     # like lib.types.oneOf but instead of a list takes an attrset
     # uses the field "type" to find the correct type in the attrset

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -16,7 +16,7 @@ let
     # a version of makeDiskImage which runs outside of the store
     makeDiskImagesScript = args: (import ./make-disk-image.nix ({ inherit diskoLib; } // args)).impure;
 
-    makeVMRunner = args: (import ./interactive-vm.nix ({ inherit diskoLib; } // args)).pure;
+    makeVMRunner = args: import ./interactive-vm.nix ({ inherit diskoLib; } // args);
 
     testLib = import ./tests.nix { inherit lib makeTest eval-config; };
     # like lib.types.oneOf but instead of a list takes an attrset

--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -1,10 +1,9 @@
-{ nixosConfig
-, diskoLib
-, pkgs ? nixosConfig.pkgs
-}:
+# We need to specify extendModules here to ensure that it is available
+# in args for makeDiskImages
+{ diskoLib, modulesPath, config, pkgs, lib, extendModules, ... }@args:
+
 let
-  lib = pkgs.lib;
-  vm_disko = (diskoLib.testLib.prepareDiskoConfig nixosConfig.config diskoLib.testLib.devices).disko;
+  vm_disko = (diskoLib.testLib.prepareDiskoConfig config diskoLib.testLib.devices).disko;
   cfg_ = (lib.evalModules {
     modules = lib.singleton {
       # _file = toString input;
@@ -22,7 +21,7 @@ let
   }).config;
   disks = lib.attrValues cfg_.disko.devices.disk;
   diskoImages = diskoLib.makeDiskImages {
-    nixosConfig = nixosConfig;
+    nixosConfig = args;
     copyNixStore = false;
     extraConfig = {
       disko.devices = cfg_.disko.devices;
@@ -45,40 +44,38 @@ let
       driveExtraOpts.werror = "report";
     })
     (builtins.tail disks);
-in nixosConfig.extendModules {
-  modules = [
-    ({ modulesPath, config, pkgs, ... }: {
-      imports = [
-        (modulesPath + "/virtualisation/qemu-vm.nix")
-      ];
 
-      virtualisation.useEFIBoot = config.disko.tests.efi;
-      virtualisation.memorySize = config.disko.memSize;
-      virtualisation.useDefaultFilesystems = false;
-      virtualisation.diskImage = null;
-      virtualisation.qemu.drives = [ rootDisk ] ++ otherDisks;
-      boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
-      boot.zfs.forceImportAll = true;
-
-      system.build.vmWithDisko = pkgs.writers.writeDashBin "disko-vm" ''
-        set -efux
-        export tmp=$(mktemp -d)
-        trap 'rm -rf "$tmp"' EXIT
-        ${lib.concatMapStringsSep "\n" (disk: ''
-          ${pkgs.qemu}/bin/qemu-img create -f qcow2 \
-          -b ${diskoImages}/${disk.name}.qcow2 \
-          -F qcow2 "$tmp"/${disk.name}.qcow2
-        '') disks}
-        set +f
-        ${config.system.build.vm}/bin/run-*-vm
-      '';
-    })
-    {
-      # generated from disko config
-      virtualisation.fileSystems = cfg_.disko.devices._config.fileSystems;
-      boot = cfg_.disko.devices._config.boot or { };
-      swapDevices = cfg_.disko.devices._config.swapDevices or [ ];
-    }
-    nixosConfig.config.disko.tests.extraConfig
+  diskoBasedConfiguration = {
+    # generated from disko config
+    virtualisation.fileSystems = cfg_.disko.devices._config.fileSystems;
+    boot = cfg_.disko.devices._config.boot or { };
+    swapDevices = cfg_.disko.devices._config.swapDevices or [ ];
+  };
+in
+{
+  imports = [
+    (modulesPath + "/virtualisation/qemu-vm.nix")
+    diskoBasedConfiguration
   ];
+
+  virtualisation.useEFIBoot = config.disko.tests.efi;
+  virtualisation.memorySize = config.disko.memSize;
+  virtualisation.useDefaultFilesystems = false;
+  virtualisation.diskImage = null;
+  virtualisation.qemu.drives = [ rootDisk ] ++ otherDisks;
+  boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
+  boot.zfs.forceImportAll = true;
+
+  system.build.vmWithDisko = pkgs.writers.writeDashBin "disko-vm" ''
+    set -efux
+    export tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    ${lib.concatMapStringsSep "\n" (disk: ''
+      ${pkgs.qemu}/bin/qemu-img create -f qcow2 \
+      -b ${diskoImages}/${disk.name}.qcow2 \
+      -F qcow2 "$tmp"/${disk.name}.qcow2
+    '') disks}
+    set +f
+    ${config.system.build.vm}/bin/run-*-vm
+  '';
 }

--- a/module.nix
+++ b/module.nix
@@ -7,6 +7,11 @@ let
     eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
   };
   cfg = config.disko;
+
+  vmVariantWithDisko = diskoLib.makeVMRunner {
+    inherit pkgs;
+    nixosConfig = args;
+  };
 in
 {
   options.disko = {
@@ -137,6 +142,16 @@ in
       };
     };
   };
+
+  options.virtualisation.vmVariantWithDisko = lib.mkOption {
+    description = ''
+      Machine configuration to be added for the vm script available at `.system.build.vmWithDisko`.
+    '';
+    inherit (vmVariantWithDisko) type;
+    default = {};
+    visible = "shallow";
+  };
+
   config = lib.mkIf (cfg.devices.disk != { }) {
     system.build = (cfg.devices._scripts { inherit pkgs; checked = cfg.checkScripts; }) // {
 
@@ -161,10 +176,7 @@ in
         extraTestScript = cfg.tests.extraChecks;
       };
 
-      vmWithDisko = diskoLib.makeVMRunner {
-        inherit pkgs;
-        nixosConfig = args;
-      };
+      vmWithDisko = lib.mkDefault config.virtualisation.vmVariantWithDisko.system.build.vmWithDisko;
     };
 
 

--- a/module.nix
+++ b/module.nix
@@ -8,9 +8,12 @@ let
   };
   cfg = config.disko;
 
-  vmVariantWithDisko = diskoLib.makeVMRunner {
-    inherit pkgs;
-    nixosConfig = args;
+  vmVariantWithDisko = extendModules {
+    modules = [
+      ./lib/interactive-vm.nix
+      { _module.args = { inherit diskoLib; }; }
+      config.disko.tests.extraConfig
+    ];
   };
 in
 {


### PR DESCRIPTION
This simplifies the code by making `interactive-vm` a NixOS module rather than a disko module that outputs a NixOS module. By adding the `virtualisation.vmVariantWithDisko` option, this allows the VM to be configured through the NixOS module system:

```nix
{
  virtualisation.vmVariantWithDisko = {
    virtualisation.fileSystems."/persist" = {
      label = "vm-persist";
    };
  };
}
```

This also allows introspection of the VM's configuration:

```
$ nix repl ~/dotfiles --override-input disko github:Enzime/disko/disko-vm
nix-repl> nixosConfigurations.sigma.config.fileSystems."/persist".label
null
nix-repl> nixosConfigurations.sigma.config.virtualisation.vmVariantWithDisko.virtualisation.fileSystems."/persist".label
"vm-persist"
```

This brings it in line with the existing NixOS VM options [virtualisation.vmVariant](https://search.nixos.org/options?channel=unstable&show=virtualisation.vmVariant&from=0&size=50&sort=relevance&type=packages&query=virtualisation.vmVariant) and [vmVariantWithBootloader](https://search.nixos.org/options?channel=unstable&show=virtualisation.vmVariantWithBootLoader&from=0&size=50&sort=relevance&type=packages&query=virtualisation.vmVariant).