### PR TITLE
make-disk-image: honor disko.memSize as default

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -200,7 +200,7 @@ in
     ''}
     export postVM=${diskoLib.writeCheckedBash { inherit pkgs checked; } "postVM.sh" postVM}
 
-    build_memory=''${build_memory:-1024}
+    build_memory=''${build_memory:-${nixosConfig.config.disko.memSize}}
     QEMU_OPTS=${lib.escapeShellArg QEMU_OPTS}
     QEMU_OPTS+=" -m $build_memory"
     export QEMU_OPTS

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -200,7 +200,7 @@ in
     ''}
     export postVM=${diskoLib.writeCheckedBash { inherit pkgs checked; } "postVM.sh" postVM}
 
-    build_memory=''${build_memory:-${nixosConfig.config.disko.memSize}}
+    build_memory=''${build_memory:-${toString nixosConfig.config.disko.memSize}}
     QEMU_OPTS=${lib.escapeShellArg QEMU_OPTS}
     QEMU_OPTS+=" -m $build_memory"
     export QEMU_OPTS


### PR DESCRIPTION
related to https://github.com/nix-community/disko/issues/769

I had to bump `memSize` to work around #769. I couldn't figure out why it needed _so much RAM_ until I realized that the module does not influence the impure script.

I think this is "ok", to plumb through the default.