### PR TITLE
make-disk-image: convert into NixOS module

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,13 +9,6 @@ with builtins;
 let
   outputs = import ../default.nix { inherit lib diskoLib; };
   diskoLib = {
-
-    # like make-disk-image.nix from nixpkgs, but with disko config
-    makeDiskImages = args: (import ./make-disk-image.nix ({ inherit diskoLib; } // args)).pure;
-
-    # a version of makeDiskImage which runs outside of the store
-    makeDiskImagesScript = args: (import ./make-disk-image.nix ({ inherit diskoLib; } // args)).impure;
-
     testLib = import ./tests.nix { inherit lib makeTest eval-config; };
     # like lib.types.oneOf but instead of a list takes an attrset
     # uses the field "type" to find the correct type in the attrset

--- a/lib/types/disk.nix
+++ b/lib/types/disk.nix
@@ -19,7 +19,7 @@
     imageSize = lib.mkOption {
       type = lib.types.strMatching "[0-9]+[KMGTP]?";
       description = ''
-        size of the image if the makeDiskImages function from diksoLib is used.
+        size of the image when disko images are created
         is used as an argument to "qemu-img create ..."
       '';
       default = "2G";

--- a/module.nix
+++ b/module.nix
@@ -1,72 +1,108 @@
-{ config, lib, pkgs, extendModules, ... }@args:
+{ config, lib, pkgs, extendModules, diskoLib, ... }:
 let
-  diskoLib = import ./lib {
-    inherit lib;
-    rootMountPoint = config.disko.rootMountPoint;
-    makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
-    eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
-  };
   cfg = config.disko;
 
   vmVariantWithDisko = extendModules {
     modules = [
       ./lib/interactive-vm.nix
-      { _module.args = { inherit diskoLib; }; }
       config.disko.tests.extraConfig
     ];
   };
 in
 {
+  imports = [ ./lib/make-disk-image.nix ];
+
   options.disko = {
-    imageBuilderQemu = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      description = ''
-        the qemu emulator string used when building disk images via make-disk-image.nix.
-        Useful when using binfmt on your build host, and wanting to build disk
-        images for a foreign architecture
-      '';
-      default = null;
-      example = lib.literalExpression "\${pkgs.qemu_kvm}/bin/qemu-system-aarch64";
+    imageBuilder = {
+      qemu = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          the qemu emulator string used when building disk images via make-disk-image.nix.
+          Useful when using binfmt on your build host, and wanting to build disk
+          images for a foreign architecture
+        '';
+        default = null;
+        example = lib.literalExpression "\${pkgs.qemu_kvm}/bin/qemu-system-aarch64";
+      };
+
+      pkgs = lib.mkOption {
+        type = lib.types.attrs;
+        description = ''
+          the pkgs instance used when building disk images via make-disk-image.nix.
+          Useful when the config's kernel won't boot in the image-builder.
+        '';
+        default = pkgs;
+        defaultText = lib.literalExpression "pkgs";
+        example = lib.literalExpression "pkgs";
+      };
+
+      kernelPackages = lib.mkOption {
+        type = lib.types.attrs;
+        description = ''
+          the kernel used when building disk images via make-disk-image.nix.
+          Useful when the config's kernel won't boot in the image-builder.
+        '';
+        default = config.boot.kernelPackages;
+        defaultText = lib.literalExpression "config.boot.kernelPackages";
+        example = lib.literalExpression "pkgs.linuxPackages_testing";
+      };
+
+      extraRootModules = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          extra kernel modules to pass to the vmTools.runCommand invocation in the make-disk-image.nix builder
+        '';
+        default = [ ];
+        example = [ "bcachefs" ];
+      };
+
+      extraPostVM = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          extra shell code to execute once the disk image(s) have been succesfully created and moved to $out
+        '';
+        default = "";
+        example = lib.literalExpression ''
+          ''${pkgs.zstd}/bin/zstd --compress $out/*raw
+          rm $out/*raw
+        '';
+      };
+
+      extraDependencies = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        description = ''
+          list of extra packages to make available in the make-disk-image.nix VM builder, an example might be f2fs-tools
+        '';
+        default = [ ];
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        description = "name for the disk images";
+        default = "${config.networking.hostName}-disko-images";
+      };
+
+      copyNixStore = lib.mkOption {
+        type = lib.types.bool;
+        description = "whether to copy the nix store into the disk images we just created";
+        default = true;
+      };
+
+      extraConfig = lib.mkOption {
+        description = ''
+          Extra NixOS config for your test. Can be used to specify a different luks key for tests.
+          A dummy key is in /tmp/secret.key
+        '';
+        default = { };
+      };
+
+      imageFormat = lib.mkOption {
+        type = lib.types.enum [ "raw" "qcow2" ];
+        description = "QEMU image format to use for the disk images";
+        default = "raw";
+      };
     };
-    imageBuilderPkgs = lib.mkOption {
-      type = lib.types.attrs;
-      description = ''
-        the pkgs instance used when building disk images via make-disk-image.nix.
-        Useful when the config's kernel won't boot in the image-builder.
-      '';
-      default = pkgs;
-      defaultText = lib.literalExpression "pkgs";
-      example = lib.literalExpression "pkgs";
-    };
-    imageBuilderKernelPackages = lib.mkOption {
-      type = lib.types.attrs;
-      description = ''
-        the kernel used when building disk images via make-disk-image.nix.
-        Useful when the config's kernel won't boot in the image-builder.
-      '';
-      default = config.boot.kernelPackages;
-      defaultText = lib.literalExpression "config.boot.kernelPackages";
-      example = lib.literalExpression "pkgs.linuxPackages_testing";
-    };
-    extraRootModules = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      description = ''
-        extra kernel modules to pass to the vmTools.runCommand invocation in the make-disk-image.nix builder
-      '';
-      default = [ ];
-      example = [ "bcachefs" ];
-    };
-    extraPostVM = lib.mkOption {
-      type = lib.types.str;
-      description = ''
-        extra shell code to execute once the disk image(s) have been succesfully created and moved to $out
-      '';
-      default = "";
-      example = lib.literalExpression ''
-        ''${pkgs.zstd}/bin/zstd --compress $out/*raw
-        rm $out/*raw
-      '';
-    };
+
     memSize = lib.mkOption {
       type = lib.types.int;
       description = ''
@@ -74,23 +110,19 @@ in
       '';
       default = 1024;
     };
+
     devices = lib.mkOption {
       type = diskoLib.toplevel;
       default = { };
       description = "The devices to set up";
     };
-    extraDependencies = lib.mkOption {
-      type = lib.types.listOf lib.types.package;
-      description = ''
-        list of extra packages to make available in the make-disk-image.nix VM builder, an example might be f2fs-tools
-      '';
-      default = [ ];
-    };
+
     rootMountPoint = lib.mkOption {
       type = lib.types.str;
       default = "/mnt";
       description = "Where the device tree should be mounted by the mountScript";
     };
+
     enableConfig = lib.mkOption {
       description = ''
         configure nixos with the specified devices
@@ -100,6 +132,7 @@ in
       type = lib.types.bool;
       default = true;
     };
+
     checkScripts = lib.mkOption {
       description = ''
         Whether to run shellcheck on script outputs
@@ -107,6 +140,7 @@ in
       type = lib.types.bool;
       default = false;
     };
+
     testMode = lib.mkOption {
       internal = true;
       description = ''
@@ -116,6 +150,7 @@ in
       type = lib.types.bool;
       default = false;
     };
+
     tests = {
       efi = lib.mkOption {
         description = ''
@@ -126,6 +161,7 @@ in
         defaultText = "config.boot.loader.systemd-boot.enable || config.boot.loader.grub.efiSupport";
         default = config.boot.loader.systemd-boot.enable || config.boot.loader.grub.efiSupport;
       };
+
       extraChecks = lib.mkOption {
         description = ''
           extra checks to run in the `system.build.installTest`.
@@ -136,6 +172,7 @@ in
           machine.succeed("test -e /var/secrets/my.secret")
         '';
       };
+
       extraConfig = lib.mkOption {
         description = ''
           Extra NixOS config for your test. Can be used to specify a different luks key for tests.
@@ -155,38 +192,41 @@ in
     visible = "shallow";
   };
 
-  config = lib.mkIf (cfg.devices.disk != { }) {
-    system.build = (cfg.devices._scripts { inherit pkgs; checked = cfg.checkScripts; }) // {
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.devices.disk != { }) {
+      system.build = (cfg.devices._scripts { inherit pkgs; checked = cfg.checkScripts; }) // {
 
-      # we keep these old outputs for compatibility
-      disko = builtins.trace "the .disko output is deprecated, please use .diskoScript instead" (cfg.devices._scripts { inherit pkgs; }).diskoScript;
-      diskoNoDeps = builtins.trace "the .diskoNoDeps output is deprecated, please use .diskoScriptNoDeps instead" (cfg.devices._scripts { inherit pkgs; }).diskoScriptNoDeps;
+        # we keep these old outputs for compatibility
+        disko = builtins.trace "the .disko output is deprecated, please use .diskoScript instead" (cfg.devices._scripts { inherit pkgs; }).diskoScript;
+        diskoNoDeps = builtins.trace "the .diskoNoDeps output is deprecated, please use .diskoScriptNoDeps instead" (cfg.devices._scripts { inherit pkgs; }).diskoScriptNoDeps;
 
-      diskoImages = diskoLib.makeDiskImages {
-        nixosConfig = args;
-      };
-      diskoImagesScript = diskoLib.makeDiskImagesScript {
-        nixosConfig = args;
-      };
+        installTest = diskoLib.testLib.makeDiskoTest {
+          inherit extendModules pkgs;
+          name = "${config.networking.hostName}-disko";
+          disko-config = builtins.removeAttrs config [ "_module" ];
+          testMode = "direct";
+          efi = cfg.tests.efi;
+          extraSystemConfig = cfg.tests.extraConfig;
+          extraTestScript = cfg.tests.extraChecks;
+        };
 
-      installTest = diskoLib.testLib.makeDiskoTest {
-        inherit extendModules pkgs;
-        name = "${config.networking.hostName}-disko";
-        disko-config = builtins.removeAttrs config [ "_module" ];
-        testMode = "direct";
-        efi = cfg.tests.efi;
-        extraSystemConfig = cfg.tests.extraConfig;
-        extraTestScript = cfg.tests.extraChecks;
+        vmWithDisko = lib.mkDefault config.virtualisation.vmVariantWithDisko.system.build.vmWithDisko;
       };
 
-      vmWithDisko = lib.mkDefault config.virtualisation.vmVariantWithDisko.system.build.vmWithDisko;
-    };
 
-
-    # we need to specify the keys here, so we don't get an infinite recursion error
-    # Remember to add config keys here if they are added to types
-    fileSystems = lib.mkIf cfg.enableConfig cfg.devices._config.fileSystems or { };
-    boot = lib.mkIf cfg.enableConfig cfg.devices._config.boot or { };
-    swapDevices = lib.mkIf cfg.enableConfig cfg.devices._config.swapDevices or [ ];
-  };
+      # we need to specify the keys here, so we don't get an infinite recursion error
+      # Remember to add config keys here if they are added to types
+      fileSystems = lib.mkIf cfg.enableConfig cfg.devices._config.fileSystems or { };
+      boot = lib.mkIf cfg.enableConfig cfg.devices._config.boot or { };
+      swapDevices = lib.mkIf cfg.enableConfig cfg.devices._config.swapDevices or [ ];
+    })
+    {
+      _module.args.diskoLib = import ./lib {
+        inherit lib;
+        rootMountPoint = config.disko.rootMountPoint;
+        makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
+        eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
+      };
+    }
+  ];
 }

--- a/tests/make-disk-image-impure.nix
+++ b/tests/make-disk-image-impure.nix
@@ -1,15 +1,13 @@
 { pkgs ? import <nixpkgs> { }
-, diskoLib ? pkgs.callPackage ../lib { }
+, ...
 }:
-diskoLib.makeDiskImagesScript {
-  nixosConfig = pkgs.nixos [
-    ../module.nix
-    ../example/simple-efi.nix
-    ({ config, ... }: {
-      documentation.enable = false;
-      system.stateVersion = config.system.nixos.version;
-    })
-  ];
-  checked = true;
-}
 
+(pkgs.nixos [
+  ../module.nix
+  ../example/simple-efi.nix
+  ({ config, ... }: {
+    documentation.enable = false;
+    system.stateVersion = config.system.nixos.version;
+    disko.checkScripts = true;
+  })
+]).config.system.build.diskoImagesScript

--- a/tests/make-disk-image.nix
+++ b/tests/make-disk-image.nix
@@ -1,14 +1,14 @@
 { pkgs ? import <nixpkgs> { }
-, diskoLib ? pkgs.callPackage ../lib { }
+, ...
 }:
-diskoLib.makeDiskImages {
-  nixosConfig = pkgs.nixos [
-    ../module.nix
-    ../example/simple-efi.nix
-    ({ config, ... }: {
-      documentation.enable = false;
-      system.stateVersion = config.system.nixos.version;
-      disko.memSize = 2048;
-    })
-  ];
-}
+
+(pkgs.nixos [
+  ../module.nix
+  ../example/simple-efi.nix
+  ({ config, ... }: {
+    documentation.enable = false;
+    system.stateVersion = config.system.nixos.version;
+    disko.memSize = 2048;
+    disko.checkScripts = true;
+  })
+]).config.system.build.diskoImages


### PR DESCRIPTION
As `makeDiskImages` always requires a NixOS configuration, we can simplify the code by converting it into a NixOS module. Then we can make it responsible for populating `system.build.diskoImages` and `system.build.diskoImagesScript`.