### PR TITLE
imageBuilder: add defaultText

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -80,6 +80,7 @@ in
         type = lib.types.str;
         description = "name for the disk images";
         default = "${config.networking.hostName}-disko-images";
+        defaultText = "\${config.networking.hostName}-disko-images";
       };
 
       copyNixStore = lib.mkOption {


### PR DESCRIPTION
otherwise documentation depends on the hostname to be set