### PR TITLE
interactive-vm: use host pkgs in the launcher script.

### DIFF
--- a/docs/interactive-vm.md
+++ b/docs/interactive-vm.md
@@ -18,6 +18,8 @@ You can configure the VM using the `virtualisation.vmVariantWithDisko` NixOS opt
 {
   virtualisation.vmVariantWithDisko = {
     virtualisation.fileSystems."/persist".neededForBoot = true;
+    # For running VM on macos: https://www.tweag.io/blog/2023-02-09-nixos-vm-on-macos/
+    # virtualisation.host.pkgs = inputs.nixpkgs.legacyPackages.aarch64-darwin;
   };
 }
 ```

--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -40,6 +40,8 @@ let
     boot = cfg_.disko.devices._config.boot or { };
     swapDevices = cfg_.disko.devices._config.swapDevices or [ ];
   };
+
+  hostPkgs = config.virtualisation.host.pkgs;
 in
 {
   imports = [
@@ -63,12 +65,12 @@ in
   boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
   boot.zfs.forceImportAll = true;
 
-  system.build.vmWithDisko = pkgs.writers.writeDashBin "disko-vm" ''
+  system.build.vmWithDisko = hostPkgs.writers.writeDashBin "disko-vm" ''
     set -efux
-    export tmp=$(mktemp -d)
+    export tmp=$(${hostPkgs.coreutils}/bin/mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
     ${lib.concatMapStringsSep "\n" (disk: ''
-      ${pkgs.qemu}/bin/qemu-img create -f qcow2 \
+      ${hostPkgs.qemu}/bin/qemu-img create -f qcow2 \
       -b ${config.system.build.diskoImages}/${disk.name}.qcow2 \
       -F qcow2 "$tmp"/${disk.name}.qcow2
     '') disks}


### PR DESCRIPTION
This change allows to use
```
virtualisation.vmVariantWithDisko.virtualisation.host.pkgs = inputs.nixpkgs.legacyPackages.aarch64-darwin;
```

to run interactive VM on aarch64-darwin system.

See: https://www.tweag.io/blog/2023-02-09-nixos-vm-on-macos/

---
Tested along with #790 
![image](https://github.com/user-attachments/assets/d622664d-ea2b-4e77-a83e-1cadb0baa747)

