### PR TITLE
interactive-vm: override `forceImportRoot`

### DIFF
--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -64,6 +64,7 @@ in
   virtualisation.qemu.drives = [ rootDisk ] ++ otherDisks;
   boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
   boot.zfs.forceImportAll = true;
+  boot.zfs.forceImportRoot = lib.mkForce true;
 
   system.build.vmWithDisko = hostPkgs.writers.writeDashBin "disko-vm" ''
     set -efux


### PR DESCRIPTION
Some users will have `boot.zfs.forceImportRoot = false;` in their configurations which conflicts with `boot.zfs.forceImportAll = true;`, so we set it to `true` to match.