### PR TITLE
Luks btrfs raid example

### DIFF
--- a/example/luks-btrfs-raid.nix
+++ b/example/luks-btrfs-raid.nix
@@ -1,0 +1,52 @@
+{
+  disko.devices = {
+    disk = {
+      disk0 = {
+        type = "disk";
+	device = "/dev/sdb";
+	content = {
+	  type = "gpt";
+	  partitions = {
+	    crypted2 = {
+	      name = "crypt_raidp2";
+	      size = "100%";
+	      content = {
+                type = "luks";
+		name = "raidp2"; # this is DM name
+	      };
+	    };
+	  };
+	};
+      };
+      disk1 = {
+        type = "disk";
+        device = "/dev/sda";
+        content = {
+          type = "gpt";
+          partitions = {
+            crypted1 = {
+              size = "100%";
+	      name = "crypt_raidp1";
+              content = {
+                type = "luks";
+		name = "raidp1";
+		content = {
+		  type = "btrfs";
+		  extraArgs = [ "-f" "-m raid1 -d raid1" "/dev/mapper/raidp2"]; # raidp2 - DM name of 2nd disk
+                  subvolumes = {
+		    "/" = {
+                      mountpoint = "/mnt/SoftWare";
+		      mountOptions = [
+		        "rw" "relatime" "ssd" "discard=async" "space_cache=v2" "subvolid=5" "subvol=/"
+		      ];
+		    };
+		  };
+		};
+	      };
+	    };
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/luks-btrfs-raid.nix
+++ b/tests/luks-btrfs-raid.nix
@@ -1,0 +1,14 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "luks-btrfs-raid";
+  disko-config = ../example/luks-btrfs-raid.nix;
+  extraTestScript = ''
+    machine.succeed("cryptsetup isLuks /dev/vda2");
+    machine.succeed("cryptsetup isLuks /dev/vdb1");
+    machine.succeed("btrfs subvolume list /");
+  '';
+}


### PR DESCRIPTION
Supersedes #802
Fixes #799

I actually feel the example was useful, spreading a btrfs atop two encrypted volumes is not trivial, and while testing I actually discovered that the alphabetical order of the devices matters here, see comment in the code. Not sure if that's something our tests cover yet.

I would've pushed to the original PR but it had the upstream set to master, which I can't push to, even with the "Allow maintainers to edit the PR" flag set.

I've left the original commit intact but can squash if necessary.