### PR TITLE
docs: Fix /boot security hole warning in examples

### DIFF
--- a/docs/HowTo.md
+++ b/docs/HowTo.md
@@ -150,6 +150,7 @@ or with pinning:
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/docs/disko-install.md
+++ b/docs/disko-install.md
@@ -65,6 +65,7 @@ example we assume a system that has been booted with EFI:
                       type = "filesystem";
                       format = "vfat";
                       mountpoint = "/boot";
+                      mountOptions = [ "umask=0077" ];
                     };
                   };
                   root = {
@@ -168,6 +169,7 @@ Add this to your flake.nix output:
                       type = "filesystem";
                       format = "vfat";
                       mountpoint = "/boot";
+                      mountOptions = [ "umask=0077" ];
                     };
                   };
                   root = {

--- a/docs/table-to-gpt.md
+++ b/docs/table-to-gpt.md
@@ -122,6 +122,7 @@ The fixed disko configuration would look like this:
             type = "filesystem";
             format = "vfat";
             mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
           };
         };
         root = {

--- a/example/bcachefs.nix
+++ b/example/bcachefs.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/example/btrfs-only-root-subvolume.nix
+++ b/example/btrfs-only-root-subvolume.nix
@@ -17,6 +17,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/example/btrfs-subvolumes.nix
+++ b/example/btrfs-subvolumes.nix
@@ -17,6 +17,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/example/complex.nix
+++ b/example/complex.nix
@@ -15,6 +15,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
           };

--- a/example/f2fs.nix
+++ b/example/f2fs.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/example/hybrid-mbr.nix
+++ b/example/hybrid-mbr.nix
@@ -29,6 +29,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/example/hybrid-tmpfs-on-root.nix
+++ b/example/hybrid-tmpfs-on-root.nix
@@ -18,6 +18,7 @@
               type = "filesystem";
               format = "vfat";
               mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
             };
           };
           nix = {

--- a/example/hybrid.nix
+++ b/example/hybrid.nix
@@ -18,6 +18,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {
@@ -34,4 +35,3 @@
     };
   };
 }
-

--- a/example/long-device-name.nix
+++ b/example/long-device-name.nix
@@ -15,6 +15,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {
@@ -31,4 +32,3 @@
     };
   };
 }
-

--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -14,9 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
-                mountOptions = [
-                  "defaults"
-                ];
+                mountOptions = [ "umask=0077" ];
               };
             };
             luks = {

--- a/example/luks-interactive-login.nix
+++ b/example/luks-interactive-login.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             luks = {

--- a/example/luks-lvm.nix
+++ b/example/luks-lvm.nix
@@ -14,9 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
-                mountOptions = [
-                  "defaults"
-                ];
+                mountOptions = [ "umask=0077" ];
               };
             };
             luks = {

--- a/example/lvm-sizes-sort.nix
+++ b/example/lvm-sizes-sort.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             primary = {

--- a/example/lvm-thin.nix
+++ b/example/lvm-thin.nix
@@ -14,9 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
-                mountOptions = [
-                  "defaults"
-                ];
+                mountOptions = [ "umask=0077" ];
               };
             };
             primary = {

--- a/example/non-root-zfs.nix
+++ b/example/non-root-zfs.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {
@@ -106,4 +107,3 @@
     };
   };
 }
-

--- a/example/simple-efi.nix
+++ b/example/simple-efi.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {
@@ -30,4 +31,3 @@
     };
   };
 }
-

--- a/example/swap.nix
+++ b/example/swap.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/example/tmpfs.nix
+++ b/example/tmpfs.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {
@@ -38,4 +39,3 @@
     };
   };
 }
-

--- a/example/zfs-over-legacy.nix
+++ b/example/zfs-over-legacy.nix
@@ -14,9 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
-                mountOptions = [
-                  "defaults"
-                ];
+                mountOptions = [ "umask=0077" ];
               };
             };
             primary = {
@@ -57,4 +55,3 @@
     };
   };
 }
-

--- a/example/zfs-with-vdevs.nix
+++ b/example/zfs-with-vdevs.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             zfs = {
@@ -84,7 +85,10 @@
             vdev = [
               {
                 mode = "mirror";
-                members = [ "x" "y" ];
+                members = [
+                  "x"
+                  "y"
+                ];
               }
             ];
             special = {

--- a/example/zfs.nix
+++ b/example/zfs.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             zfs = {
@@ -102,4 +103,3 @@
     };
   };
 }
-


### PR DESCRIPTION
The alternative would be to do this automatically if format=="vfat" and mountpoint=="/boot", but it's better to be upfront about this.

Fixes #527