### PR TITLE
enable LUKS initrdUnlock only if Systemd's initrd available by default

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -81,7 +81,7 @@ in
     };
     initrdUnlock = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = config.boot.initrd.systemd.enable;
       description = "Whether to add a boot.initrd.luks.devices entry for the specified disk.";
     };
     extraFormatArgs = lib.mkOption {


### PR DESCRIPTION
I could be wrong but I am pretty sure without Systemd's initrd available this will not function so I think it should be dependent on the state of boot.initrd.systemd.enable not always enabled.