### PR TITLE
interactive-vm: allow to override virtualisation.memorySize

### DIFF
--- a/docs/interactive-vm.md
+++ b/docs/interactive-vm.md
@@ -5,13 +5,7 @@ config.system.build.vm). Simply import the disko module and build the vm runner
 with:
 
 ```
-nix build -L '.#nixosConfigurations.mymachine.config.system.build.vmWithDisko'
-```
-
-afterwards you can run the interactive VM with:
-
-```
-result/bin/disko-vm
+nix run -L '.#nixosConfigurations.mymachine.config.system.build.vmWithDisko'
 ```
 
 You can configure the VM using the `virtualisation.vmVariantWithDisko` NixOS

--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -58,7 +58,7 @@ in
   disko.imageBuilder.imageFormat = "qcow2";
 
   virtualisation.useEFIBoot = config.disko.tests.efi;
-  virtualisation.memorySize = config.disko.memSize;
+  virtualisation.memorySize = lib.mkDefault config.disko.memSize;
   virtualisation.useDefaultFilesystems = false;
   virtualisation.diskImage = null;
   virtualisation.qemu.drives = [ rootDisk ] ++ otherDisks;


### PR DESCRIPTION
Users might set this value for building images but than need different values when they run interactive virtual machines.