### PR TITLE
Allow config to be dumped to json file

### DIFF
--- a/cli.nix
+++ b/cli.nix
@@ -24,6 +24,7 @@ let
         # legacy aliases
         create = "createScriptNoDeps";
         zap_create_mount = "diskoScriptNoDeps";
+        config = "configFile";
       }.${mode}
     else
       {
@@ -34,6 +35,7 @@ let
         # legacy aliases
         create = "createScript";
         zap_create_mount = "diskoScript";
+        config = "configFile";
       }.${mode};
 
   hasDiskoConfigFlake =

--- a/default.nix
+++ b/default.nix
@@ -40,5 +40,7 @@ in
   diskoNoDeps = cfg: pkgs: builtins.trace "the diskoNoDeps output is deprecated, please use disko instead" ((eval cfg).config.disko.devices._scripts { inherit pkgs checked; }).diskoScriptNoDeps;
 
   config = cfg: (eval cfg).config.disko.devices._config;
+  configFile = cfg: pkgs: pkgs.writers.writeJSON "config.json" cfg.disko.devices;
+
   packages = cfg: (eval cfg).config.disko.devices._packages;
 }


### PR DESCRIPTION
I'll accept any tips&tricks on this one, I'm still learning Nix
Necessary for https://github.com/nix-community/disko/issues/789

Tested via following script:
```
#!/usr/bin/env nu
ls example
| where type == file
| update name {path expand}
| par-each {|example|
    let dir_name = ('configs'|path join ($example.name|path parse|get stem))
    mkdir $dir_name
    let store_path = (nix-build ./cli.nix --argstr mode config --no-out-link --arg diskoFile $example.name)
        cp $store_path $dir_name
}
```