### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ a disk named /dev/sda, you would run the following command to partition, format
 and mount the disk.
 
 ```console
-sudo nix --experimental-features "nix-command flakes" run github:nix-community/disko -- --mode disko /tmp/disk-config.nix
+sudo nix --experimental-features "nix-command flakes" run github:nix-community/disko/latest -- --mode disko /tmp/disk-config.nix
 ```
 
 ## Related Tools

--- a/disko
+++ b/disko
@@ -10,6 +10,10 @@ declare disko_config
 mode=mount
 nix_args=()
 
+# DISKO_VERSION is set by the wrapper in package.nix
+DISKO_VERSION="${DISKO_VERSION:="unknown! This is a bug, please report it!"}"
+onlyPrintVersion=false
+
 showUsage() {
   cat <<USAGE
 Usage: $0 [options] disk-config.nix
@@ -92,6 +96,9 @@ while [[ $# -gt 0 ]]; do
     --show-trace)
       nix_args+=("$1")
       ;;
+    --version)
+      onlyPrintVersion=true
+      ;;
     *)
       if [ -z ${disko_config+x} ]; then
         disko_config=$1
@@ -103,6 +110,13 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+if [[ "$onlyPrintVersion" = true ]]; then
+  echo "$DISKO_VERSION"
+  exit 0
+fi
+# Always print version information to help with debugging
+echo "disko version $DISKO_VERSION"
 
 nixBuild() {
   if command -v nom-build > /dev/null; then

--- a/docs/HowTo.md
+++ b/docs/HowTo.md
@@ -22,7 +22,7 @@ If you use nix flakes support:
 
 ```nix
 {
-  inputs.disko.url = "github:nix-community/disko";
+  inputs.disko.url = "github:nix-community/disko/latest";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, nixpkgs, disko }: {

--- a/docs/disko-images.md
+++ b/docs/disko-images.md
@@ -20,7 +20,7 @@ In the this example we create a flake containing a nixos configuration for
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    disko.url = "github:nix-community/disko";
+    disko.url = "github:nix-community/disko/latest";
     disko.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/docs/disko-install.md
+++ b/docs/disko-install.md
@@ -22,7 +22,7 @@ For a fresh installation, where **disko-install** will handle partitioning and
 setting up the disk, use the following syntax:
 
 ```console
-sudo nix run 'github:nix-community/disko#disko-install' -- --flake <flake-url>#<flake-attr> --disk <disk-name> <disk-device>
+sudo nix run 'github:nix-community/disko#disko-install/latest' -- --flake <flake-url>#<flake-attr> --disk <disk-name> <disk-device>
 ```
 
 Example:
@@ -36,7 +36,7 @@ example we assume a system that has been booted with EFI:
 ```nix
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-  inputs.disko.url = "github:nix-community/disko";
+  inputs.disko.url = "github:nix-community/disko/latest";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, disko, nixpkgs }: {
@@ -107,7 +107,7 @@ nvme0n1     259:0    0  1.8T  0 disk
 In our example, we want to install to a USB-stick (/dev/sda):
 
 ```console
-$ sudo nix run 'github:nix-community/disko#disko-install' -- --flake '/tmp/config/etc/nixos#mymachine' --disk main /dev/sda
+$ sudo nix run 'github:nix-community/disko/latest#disko-install' -- --flake '/tmp/config/etc/nixos#mymachine' --disk main /dev/sda
 ```
 
 Afterwards you can test your USB-stick by either selecting during the boot or
@@ -126,7 +126,7 @@ new hardware or to prioritize it in your current machine's boot order, use the
 --write-efi-boot-entries option:
 
 ```console
-$ sudo nix run 'github:nix-community/disko#disko-install' -- --write-efi-boot-entries --flake '/tmp/config/etc/nixos#mymachine' --disk main /dev/sda
+$ sudo nix run 'github:nix-community/disko/latest#disko-install' -- --write-efi-boot-entries --flake '/tmp/config/etc/nixos#mymachine' --disk main /dev/sda
 ```
 
 This command installs NixOS with **disko-install** and sets the newly installed

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -129,7 +129,7 @@ The following step will partition and format your disk, and mount it to `/mnt`.
 **Please note: This will erase any existing data on your disk.**
 
 ```console
-sudo nix --experimental-features "nix-command flakes" run github:nix-community/disko -- --mode disko /tmp/disk-config.nix
+sudo nix --experimental-features "nix-command flakes" run github:nix-community/disko/latest -- --mode disko /tmp/disk-config.nix
 ```
 
 After the command has run, your file system should have been formatted and

--- a/package.nix
+++ b/package.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, makeWrapper, lib, path, nix, coreutils, nixos-install-tools, binlore }:
+{ stdenvNoCC, makeWrapper, lib, path, nix, coreutils, nixos-install-tools, binlore, diskoVersion }:
 
 let
   self = stdenvNoCC.mkDerivation (finalAttrs: {
@@ -15,6 +15,7 @@ let
         sed -e "s|libexec_dir=\".*\"|libexec_dir=\"$out/share/disko\"|" "$i" > "$out/bin/$i"
         chmod 755 "$out/bin/$i"
         wrapProgram "$out/bin/$i" \
+          --set DISKO_VERSION "${diskoVersion}" \
           --prefix PATH : ${lib.makeBinPath [ nix coreutils nixos-install-tools ]} \
           --prefix NIX_PATH : "nixpkgs=${path}"
       done

--- a/scripts/create-release.nix
+++ b/scripts/create-release.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  writeShellApplication,
+  bash,
+  coreutils,
+  git,
+  nix-fast-build,
+}:
+writeShellApplication {
+  name = "create-release";
+  runtimeInputs = [
+    bash
+    git
+    coreutils
+    nix-fast-build
+  ];
+  text = lib.readFile ./create-release.sh;
+}

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -48,6 +48,7 @@ echo "{ version = \"$version\"; released = true; }" > version.nix
 # Commit and tag the release
 git commit -am "release: v$version"
 git tag -a "v$version" -m "release: v$version"
+git tag -a "latest" -m "release: v$version"
 
 # a revsion suffix when run from the tagged release commit
 echo "{ version = \"$version\"; released = false; }" > version.nix

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,56 @@
+# Don't run directly! Instead, use
+# nix run .#create-release
+
+version=${1:-}
+if [[ -z "$version" ]]; then
+  echo "USAGE: nix run .#create-release -- <version>" >&2
+  exit 1
+fi
+
+# Check if we're running from the root of the repository
+if [[ ! -f "flake.nix" || ! -f "version.nix" ]]; then
+  echo "This script must be run from the root of the repository" >&2
+  exit 1
+fi
+
+# Check if the version matches the semver pattern (without suffixes)
+semver_regex="^([0-9]+)\.([0-9]+)\.([0-9]+)$"
+if [[ ! "$version" =~ $semver_regex ]]; then
+  echo "Version must match the semver pattern (e.g., 1.0.0, 2.3.4)" >&2
+  exit 1
+fi
+
+if [[ "$(git symbolic-ref --short HEAD)" != "master" ]]; then
+  echo "must be on master branch" >&2
+  exit 1
+fi
+
+# Ensure there are no uncommitted or unpushed changes
+uncommited_changes=$(git diff --compact-summary)
+if [[ -n "$uncommited_changes" ]]; then
+  echo -e "There are uncommited changes, exiting:\n${uncommited_changes}" >&2
+  exit 1
+fi
+git pull git@github.com:nix-community/disko master
+unpushed_commits=$(git log --format=oneline origin/master..master)
+if [[ "$unpushed_commits" != "" ]]; then
+  echo -e "\nThere are unpushed changes, exiting:\n$unpushed_commits" >&2
+  exit 1
+fi
+
+# Run all tests to ensure we don't release a broken version
+# Two workers are safe on systems with at least 16GB of RAM
+nix-fast-build --no-link -j 2 --eval-workers 2 --flake .#checks
+
+# Update the version file
+echo "{ version = \"$version\"; released = true; }" > version.nix
+
+# Commit and tag the release
+git commit -am "release: v$version"
+git tag -a "v$version" -m "release: v$version"
+
+# a revsion suffix when run from the tagged release commit
+echo "{ version = \"$version\"; released = false; }" > version.nix
+git commit -am "release: reset released flag"
+
+echo "now run 'git push --tags origin master'"

--- a/tests/disko-install/default.nix
+++ b/tests/disko-install/default.nix
@@ -1,6 +1,6 @@
-{ pkgs ? import <nixpkgs> { }, self }:
+{ pkgs ? import <nixpkgs> { }, self, diskoVersion }:
 let
-  disko = pkgs.callPackage ../../package.nix { };
+  disko = pkgs.callPackage ../../package.nix { inherit diskoVersion; };
 
   dependencies = [
     self.nixosConfigurations.testmachine.pkgs.stdenv.drvPath

--- a/version.nix
+++ b/version.nix
@@ -1,0 +1,1 @@
+{ version = "1.8.0"; released = false; }


### PR DESCRIPTION
Fixes #745

This adds a script to create a release. Running it will create two
commits that would appear like this in `git log --oneline`:

    67b5fff (master) release: reset released flag
    0b808f3 (tag: v1.8.1) release: v1.8.1
    100d2f3 docs: last change before release

It also re-creates the `version.nix` file, which is used by the flake
to determine the final version the disko CLI will print.

If `disko --version` is run from exactly the commit tagged `v1.8.1`, it
will print `1.8.1`. If it is run from any commit past that (like
master), it will print `1.8.1-67b5fff`, and if it is run from a local
folder with uncommitted changes, it will print `1.8.1-67b5fff-dirty`.

I decided that the version should always be printed as well. This should make it easy to determine whether users were running an outdated version when reporting an issue.

Additionally, I added the version tag to all flake references of the docs. This ensures that people will always use the current release, not just whatever the current master is.
The release script will update this as well. I understand this might be a controversial step, and I'm happy to hear arguments against it.

When this PR is merged, I would like to make a v1.8.1 release and update the disko package in nixpkgs as well so starting with NixOS 24.11, disko can report its own version properly.