### PR TITLE
Fix whitespace handling

### DIFF
--- a/example/gpt-name-with-whitespace.nix
+++ b/example/gpt-name-with-whitespace.nix
@@ -17,12 +17,19 @@
               };
             };
             "name with spaces" = {
-              type = "EF00";
               size = "100M";
               content = {
                 type = "filesystem";
                 format = "vfat";
-                mountpoint = "/name_with_spaces";
+                mountpoint = "/name with spaces";
+              };
+            };
+            "name^with\\some@special#chars" = {
+              size = "100M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/name^with\\some@special#chars";
               };
             };
             root = {

--- a/example/gpt-name-with-whitespace.nix
+++ b/example/gpt-name-with-whitespace.nix
@@ -1,0 +1,41 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        device = "/dev/disk/by-id/some-disk-id";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              type = "EF00";
+              size = "100M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            "name with spaces" = {
+              type = "EF00";
+              size = "100M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/name_with_spaces";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/example/legacy-table-with-whitespace.nix
+++ b/example/legacy-table-with-whitespace.nix
@@ -21,8 +21,8 @@
             }
             {
               name = "name with spaces";
-              start = "1MiB";
-              end = "100MiB";
+              start = "100MiB";
+              end = "200MiB";
               bootable = true;
               content = {
                 type = "filesystem";
@@ -32,7 +32,7 @@
             }
             {
               name = "root";
-              start = "100MiB";
+              start = "200MiB";
               end = "100%";
               part-type = "primary";
               bootable = true;

--- a/example/legacy-table-with-whitespace.nix
+++ b/example/legacy-table-with-whitespace.nix
@@ -1,0 +1,50 @@
+{
+  disko.devices = {
+    disk = {
+      vdb = {
+        device = "/dev/sda";
+        type = "disk";
+        content = {
+          type = "table";
+          format = "gpt";
+          partitions = [
+            {
+              name = "ESP";
+              start = "1MiB";
+              end = "100MiB";
+              bootable = true;
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            }
+            {
+              name = "name with spaces";
+              start = "1MiB";
+              end = "100MiB";
+              bootable = true;
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/name_with_spaces";
+              };
+            }
+            {
+              name = "root";
+              start = "100MiB";
+              end = "100%";
+              part-type = "primary";
+              bootable = true;
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -20,7 +20,7 @@ let
   disks = lib.attrValues cfg_.disko.devices.disk;
   rootDisk = {
     name = "root";
-    file = ''"$tmp"/${(builtins.head disks).name}.qcow2'';
+    file = ''"$tmp/${(builtins.head disks).name}.qcow2"'';
     driveExtraOpts.cache = "writeback";
     driveExtraOpts.werror = "report";
     deviceExtraOpts.bootindex = "1";
@@ -29,7 +29,7 @@ let
   otherDisks = map
     (disk: {
       name = disk.name;
-      file = ''"$tmp"/${disk.name}.qcow2'';
+      file = ''"$tmp/${disk.name}.qcow2"'';
       driveExtraOpts.werror = "report";
     })
     (builtins.tail disks);
@@ -72,8 +72,8 @@ in
     trap 'rm -rf "$tmp"' EXIT
     ${lib.concatMapStringsSep "\n" (disk: ''
       ${hostPkgs.qemu}/bin/qemu-img create -f qcow2 \
-      -b ${config.system.build.diskoImages}/${disk.name}.qcow2 \
-      -F qcow2 "$tmp"/${disk.name}.qcow2
+      -b "${config.system.build.diskoImages}/${disk.name}.qcow2" \
+      -F qcow2 "$tmp/${disk.name}.qcow2"
     '') disks}
     set +f
     ${config.system.build.vm}/bin/run-*-vm

--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -135,7 +135,7 @@ in
       inherit config options;
       default = ''
         # create the filesystem only if the device seems empty
-        if ! (blkid '${config.device}' -o export | grep -q '^TYPE='); then
+        if ! (blkid "${config.device}" -o export | grep -q '^TYPE='); then
           mkfs.btrfs "${config.device}" ${toString config.extraArgs}
         fi
         ${lib.optionalString (config.swap != {} || config.subvolumes != {}) ''
@@ -151,7 +151,7 @@ in
             ${lib.concatMapStrings (subvol: ''
               (
                 MNTPOINT=$(mktemp -d)
-                mount ${config.device} "$MNTPOINT" -o subvol=/
+                mount "${config.device}" "$MNTPOINT" -o subvol=/
                 trap 'umount $MNTPOINT; rm -rf $MNTPOINT' EXIT
                 SUBVOL_ABS_PATH="$MNTPOINT/${subvol.name}"
                 mkdir -p "$(dirname "$SUBVOL_ABS_PATH")"
@@ -177,8 +177,8 @@ in
                 (subvol.mountpoint != null)
                 {
                   ${subvol.mountpoint} = ''
-                    if ! findmnt ${config.device} "${rootMountPoint}${subvol.mountpoint}" > /dev/null 2>&1; then
-                      mount ${config.device} "${rootMountPoint}${subvol.mountpoint}" \
+                    if ! findmnt "${config.device}" "${rootMountPoint}${subvol.mountpoint}" > /dev/null 2>&1; then
+                      mount "${config.device}" "${rootMountPoint}${subvol.mountpoint}" \
                       ${lib.concatMapStringsSep " " (opt: "-o ${opt}") (subvol.mountOptions ++ [ "subvol=${subvol.name}" ])} \
                       -o X-mount.mkdir
                     fi
@@ -190,8 +190,8 @@ in
         {
           fs = subvolMounts // lib.optionalAttrs (config.mountpoint != null) {
             ${config.mountpoint} = ''
-              if ! findmnt ${config.device} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
-                mount ${config.device} "${rootMountPoint}${config.mountpoint}" \
+              if ! findmnt "${config.device}" "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
+                mount "${config.device}" "${rootMountPoint}${config.mountpoint}" \
                 ${lib.concatMapStringsSep " " (opt: "-o ${opt}") config.mountOptions} \
                 -o X-mount.mkdir
               fi

--- a/lib/types/filesystem.nix
+++ b/lib/types/filesystem.nix
@@ -44,10 +44,10 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        if ! (blkid '${config.device}' | grep -q 'TYPE='); then
+        if ! (blkid "${config.device}" | grep -q 'TYPE='); then
           mkfs.${config.format} \
             ${lib.escapeShellArgs config.extraArgs} \
-            ${config.device}
+            "${config.device}"
         fi
       '';
     };
@@ -55,8 +55,8 @@
       inherit config options;
       default = lib.optionalAttrs (config.mountpoint != null) {
         fs.${config.mountpoint} = ''
-          if ! findmnt ${config.device} "${rootMountPoint}${config.mountpoint}" >/dev/null 2>&1; then
-            mount ${config.device} "${rootMountPoint}${config.mountpoint}" \
+          if ! findmnt "${config.device}" "${rootMountPoint}${config.mountpoint}" >/dev/null 2>&1; then
+            mount "${config.device}" "${rootMountPoint}${config.mountpoint}" \
               -t "${config.format}" \
               ${lib.concatMapStringsSep " " (opt: "-o ${lib.escapeShellArg opt}") config.mountOptions} \
               -o X-mount.mkdir

--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -21,7 +21,7 @@ let
     ${lib.optionalString (lib.hasAttr "keyFileOffset" config.settings) "--keyfile-offset ${builtins.toString config.settings.keyFileOffset}"} \
   '';
   cryptsetupOpen = ''
-    cryptsetup open ${config.device} ${config.name} \
+    cryptsetup open "${config.device}" "${config.name}" \
       ${lib.optionalString (config.settings.allowDiscards or false) "--allow-discards"} \
       ${lib.optionalString (config.settings.bypassWorkqueues or false) "--perf-no_read_workqueue --perf-no_write_workqueue"} \
       ${toString config.extraOpenArgs} \
@@ -132,10 +132,10 @@ in
               echo "Passwords did not match, please try again."
             done
           ''}
-          cryptsetup -q luksFormat ${config.device} ${toString config.extraFormatArgs} ${keyFileArgs}
+          cryptsetup -q luksFormat "${config.device}" ${toString config.extraFormatArgs} ${keyFileArgs}
           ${cryptsetupOpen} --persistent
           ${toString (lib.forEach config.additionalKeyFiles (keyFile: ''
-            cryptsetup luksAddKey ${config.device} ${keyFile} ${keyFileArgs}
+            cryptsetup luksAddKey "${config.device}" ${keyFile} ${keyFileArgs}
           ''))}
         fi
         ${lib.optionalString (config.content != null) config.content._create}
@@ -149,7 +149,7 @@ in
         in
         {
           dev = ''
-            if ! cryptsetup status ${config.name} >/dev/null 2>/dev/null; then
+            if ! cryptsetup status "${config.name}" >/dev/null 2>/dev/null; then
               ${lib.optionalString config.askPassword ''
                 if [ -z ''${IN_DISKO_TEST+x} ]; then
                   set +x

--- a/lib/types/lvm_pv.nix
+++ b/lib/types/lvm_pv.nix
@@ -31,10 +31,10 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        if ! (blkid '${config.device}' | grep -q 'TYPE='); then
-          pvcreate ${config.device}
+        if ! (blkid "${config.device}" | grep -q 'TYPE='); then
+          pvcreate "${config.device}"
         fi
-        echo "${config.device}" >>"$disko_devices_dir"/lvm_${config.vg}
+        echo "${config.device}" >>"$disko_devices_dir/lvm_${config.vg}"
       '';
     };
     _mount = diskoLib.mkMountOption {

--- a/lib/types/lvm_vg.nix
+++ b/lib/types/lvm_vg.nix
@@ -84,23 +84,23 @@ in
         in
         ''
           ${lib.concatMapStringsSep "\n" (k: ''modprobe "${k}"'') kernelModules}
-          readarray -t lvm_devices < <(cat "$disko_devices_dir"/lvm_${config.name})
+          readarray -t lvm_devices < <(cat "$disko_devices_dir/lvm_${config.name}")
           if ! vgdisplay "${config.name}" >/dev/null; then
-            vgcreate ${config.name} \
+            vgcreate "${config.name}" \
               "''${lvm_devices[@]}"
           fi
           ${lib.concatMapStrings (lv: ''
-            if ! lvdisplay '${config.name}/${lv.name}'; then
+            if ! lvdisplay "${config.name}/${lv.name}"; then
               lvcreate \
                 --yes \
                 ${if (lv.lvm_type == "thinlv") then "-V"
                   else if lib.hasInfix "%" lv.size then "-l" else "-L"} \
                   ${lv.size} \
-                -n ${lv.name} \
+                -n "${lv.name}" \
                 ${lib.optionalString (lv.lvm_type == "thinlv") "--thinpool=${lv.pool}"} \
                 ${lib.optionalString (lv.lvm_type != null && lv.lvm_type != "thinlv") "--type=${lv.lvm_type}"} \
                 ${toString lv.extraArgs} \
-                ${config.name}
+                "${config.name}"
             fi
           '') sortedLvs}
 

--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -34,20 +34,20 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        if ! test -e /dev/md/${config.name}; then
-          readarray -t disk_devices < <(cat "$disko_devices_dir"/raid_${config.name})
-          echo 'y' | mdadm --create /dev/md/${config.name} \
+        if ! test -e "/dev/md/${config.name}"; then
+          readarray -t disk_devices < <(cat "$disko_devices_dir/raid_${config.name}")
+          echo 'y' | mdadm --create "/dev/md/${config.name}" \
             --level=${toString config.level} \
-            --raid-devices="$(wc -l "$disko_devices_dir"/raid_${config.name} | cut -f 1 -d " ")" \
+            --raid-devices="$(wc -l "$disko_devices_dir/raid_${config.name}" | cut -f 1 -d " ")" \
             --metadata=${config.metadata} \
             --force \
             --homehost=any \
             "''${disk_devices[@]}"
-          partprobe /dev/md/${config.name}
+          partprobe "/dev/md/${config.name}"
           udevadm trigger --subsystem-match=block
           udevadm settle
           # for some reason mdadm devices spawn with an existing partition table, so we need to wipe it
-          sgdisk --zap-all /dev/md/${config.name}
+          sgdisk --zap-all "/dev/md/${config.name}"
         fi
         ${lib.optionalString (config.content != null) config.content._create}
       '';

--- a/lib/types/mdraid.nix
+++ b/lib/types/mdraid.nix
@@ -32,7 +32,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        echo "${config.device}" >>"$disko_devices_dir"/raid_${config.name}
+        echo "${config.device}" >>"$disko_devices_dir/raid_${config.name}"
       '';
     };
     _mount = diskoLib.mkMountOption {

--- a/lib/types/nodev.nix
+++ b/lib/types/nodev.nix
@@ -42,7 +42,7 @@
       default = lib.optionalAttrs (config.mountpoint != null) {
         fs.${config.mountpoint} = ''
           if ! findmnt ${config.fsType} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
-            mount -t ${config.fsType} ${config.device} "${rootMountPoint}${config.mountpoint}" \
+            mount -t ${config.fsType} "${config.device}" "${rootMountPoint}${config.mountpoint}" \
             ${lib.concatMapStringsSep " " (opt: "-o ${opt}") config.mountOptions} \
             -o X-mount.mkdir
           fi

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -71,7 +71,7 @@
         if ! blkid "${config.device}" -o export | grep -q '^TYPE='; then
           mkswap \
             ${toString config.extraArgs} \
-            ${config.device}
+            "${config.device}"
         fi
       '';
     };
@@ -80,7 +80,7 @@
       # TODO: we don't support encrypted swap yet
       default = lib.optionalAttrs (!config.randomEncryption) {
         fs.${config.device} = ''
-          if ! swapon --show | grep -q "^$(readlink -f ${config.device}) "; then
+          if ! swapon --show | grep -q "^$(readlink -f "${config.device}") "; then
             swapon ${
               lib.optionalString (config.discardPolicy != null)
                 "--discard${lib.optionalString (config.discardPolicy != "both")
@@ -90,7 +90,7 @@
                 "--priority=${toString config.priority}"
               } \
               --options=${lib.concatStringsSep "," config.mountOptions} \
-              ${config.device}
+              "${config.device}"
           fi
         '';
       };

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -91,26 +91,26 @@
         inherit config options;
         default = ''
           if ! blkid "${config.device}" >/dev/null; then
-            parted -s ${config.device} -- mklabel ${config.format}
+            parted -s "${config.device}" -- mklabel ${config.format}
             ${lib.concatStrings (map (partition: ''
               ${lib.optionalString (config.format == "gpt") ''
-                parted -s ${config.device} -- mkpart ${partition.name} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
+                parted -s "${config.device}" -- mkpart "${diskoLib.hexEscapeUdevSymlink partition.name}" ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
               ''}
               ${lib.optionalString (config.format == "msdos") ''
-                parted -s ${config.device} -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
+                parted -s "${config.device}" -- mkpart ${partition.part-type} ${diskoLib.maybeStr partition.fs-type} ${partition.start} ${partition.end}
               ''}
               # ensure /dev/disk/by-path/..-partN exists before continuing
-              partprobe ${config.device}
+              partprobe "${config.device}"
               udevadm trigger --subsystem-match=block
               udevadm settle
               ${lib.optionalString partition.bootable ''
-                parted -s ${config.device} -- set ${toString partition._index} boot on
+                parted -s "${config.device}" -- set ${toString partition._index} boot on
               ''}
               ${lib.concatMapStringsSep "" (flag: ''
-                parted -s ${config.device} -- set ${toString partition._index} ${flag} on
+                parted -s "${config.device}" -- set ${toString partition._index} ${flag} on
               '') partition.flags}
               # ensure further operations can detect new partitions
-              partprobe ${config.device}
+              partprobe "${config.device}"
               udevadm trigger --subsystem-match=block
               udevadm settle
             '') config.partitions)}

--- a/lib/types/zfs.nix
+++ b/lib/types/zfs.nix
@@ -31,7 +31,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        echo "${config.device}" >>"$disko_devices_dir"/zfs_${config.pool}
+        echo "${config.device}" >>"$disko_devices_dir/zfs_${config.pool}"
       '';
     };
     _mount = diskoLib.mkMountOption {

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -47,12 +47,12 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        if ! zfs get type ${config._parent.name}/${config.name} >/dev/null 2>&1; then
-          zfs create ${config._parent.name}/${config.name} \
+        if ! zfs get type "${config._parent.name}/${config.name}" >/dev/null 2>&1; then
+          zfs create "${config._parent.name}/${config.name}" \
             ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
             -V ${config.size}
           zvol_wait
-          partprobe /dev/zvol/${config._parent.name}/${config.name}
+          partprobe "/dev/zvol/${config._parent.name}/${config.name}"
           udevadm trigger --subsystem-match=block
           udevadm settle
         fi

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -79,7 +79,7 @@ in
                     };
                     cache = lib.mkOption {
                       type = lib.types.listOf lib.types.str;
-                      default = [];
+                      default = [ ];
                       description = ''
                         A dedicated zfs cache device (L2ARC). See
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#Cache_Devices
@@ -146,14 +146,14 @@ in
           topology = lib.optionalAttrs hasTopology config.mode.topology;
         in
         ''
-          readarray -t zfs_devices < <(cat "$disko_devices_dir"/zfs_${config.name})
+          readarray -t zfs_devices < <(cat "$disko_devices_dir/zfs_${config.name}")
           if [ ''${#zfs_devices[@]} -eq 0 ]; then
             echo "no devices found for zpool ${config.name}. Did you misspell the pool name?" >&2
             exit 1
           fi
           # Try importing the pool without mounting anything if it exists.
           # This allows us to set mounpoints.
-          if zpool import -N -f '${config.name}' || zpool list '${config.name}'; then
+          if zpool import -N -f "${config.name}" || zpool list "${config.name}"; then
             echo "not creating zpool ${config.name} as a pool with that name already exists" >&2
           else
             continue=1
@@ -206,13 +206,13 @@ in
               fi
             fi
             if [ $continue -eq 1 ]; then
-              zpool create -f ${config.name} \
+              zpool create -f "${config.name}" \
                 -R ${rootMountPoint} \
                 ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
                 ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
                 ''${topology:+ $topology}
-              if [[ $(zfs get -H mounted ${config.name} | cut -f3) == "yes" ]]; then
-                zfs unmount ${config.name}
+              if [[ $(zfs get -H mounted "${config.name}" | cut -f3) == "yes" ]]; then
+                zfs unmount "${config.name}"
               fi
             fi
           fi
@@ -227,8 +227,8 @@ in
         in
         {
           dev = ''
-            zpool list '${config.name}' >/dev/null 2>/dev/null ||
-              zpool import -l -R ${rootMountPoint} '${config.name}'
+            zpool list "${config.name}" >/dev/null 2>/dev/null ||
+              zpool import -l -R ${rootMountPoint} "${config.name}"
             ${lib.concatMapStrings (x: x.dev or "") (lib.attrValues datasetMounts)}
           '';
           fs = datasetMounts.fs or { };

--- a/tests/gpt-name-with-special-chars.nix
+++ b/tests/gpt-name-with-special-chars.nix
@@ -7,6 +7,7 @@ diskoLib.testLib.makeDiskoTest {
   disko-config = ../example/gpt-name-with-whitespace.nix;
   extraTestScript = ''
     machine.succeed("mountpoint /");
-    machine.succeed("mountpoint /name_with_spaces");
+    machine.succeed("mountpoint '/name with spaces'");
+    machine.succeed("mountpoint '/name^with\\some@special#chars'");
   '';
 }

--- a/tests/gpt-name-with-whitespace.nix
+++ b/tests/gpt-name-with-whitespace.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "gpt-name-with-whitespace";
+  disko-config = ../example/gpt-name-with-whitespace.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+    machine.succeed("mountpoint /name_with_spaces");
+  '';
+}

--- a/tests/legacy-table-with-whitespace.nix
+++ b/tests/legacy-table-with-whitespace.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "legacy-table-with-whitespace";
+  disko-config = ../example/legacy-table-with-whitespace.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+    machine.succeed("mountpoint /name_with_spaces");
+  '';
+}


### PR DESCRIPTION
Fixes #130
Closes #330 

This should fix pretty much all cases where spaces or other special
characters would break disko due to improper quoting. I searched for all
instances of '.label', '.device' and '.name', so I believe I caught
whatever I could.

In some cases I changed single quotes to double quotes for consistency.

I know we don't usually fix bugs in the legacy table type, but it was so
easy I couldn't resist.