### PR TITLE
Fix eval on darwin by avoiding calling splitString with an empty string

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,15 +105,12 @@ let
       hexEscapeUdevSymlink "all0these@char#acters+_are-allow.ed"
       => "all0these@char#acters+_are-allow.ed"
     */
-    hexEscapeUdevSymlink = with lib; let
+    hexEscapeUdevSymlink = let
       allowedChars = "[0-9A-Za-z#+-.:=@_/]";
-      charToHex = c: toHexString (strings.charToInt c);
+      charToHex = c: lib.toHexString (lib.strings.charToInt c);
     in
-    str: pipe str [
-      (splitString "")
-      (map (c: if match allowedChars c != null || c == "" then c else "\\x" + charToHex c))
-      concatStrings
-    ];
+    lib.stringAsChars
+      (c: if lib.match allowedChars c != null || c == "" then c else "\\x" + charToHex c);
 
     /* get the index an item in a list
 


### PR DESCRIPTION
because it breaks evaluation on darwin with at least nix 2.18.

Evaluating `lib.splitString "" "foo"` throws the following: `error: invalid regular expression ''`.
You should be able to reproduce by just running `nix flake check` in the disko repository on darwin.

We could avoid that by using lib.stringToCharacters, but as we are mapping over it anyway, lib.stringAsChars seems to be an even better fit.

I tested the examples in hexEscapeUdevSymlinks docstring manually in a nix repl.