### PR TITLE
lvm_vg: fix size=100% leading to crash

### DIFF
--- a/example/luks-lvm.nix
+++ b/example/luks-lvm.nix
@@ -45,7 +45,7 @@
         type = "lvm_vg";
         lvs = {
           root = {
-            size = "100M";
+            size = "100%";
             content = {
               type = "filesystem";
               format = "ext4";

--- a/lib/types/lvm_vg.nix
+++ b/lib/types/lvm_vg.nix
@@ -95,7 +95,7 @@ in
                 --yes \
                 ${if (lv.lvm_type == "thinlv") then "-V"
                   else if lib.hasInfix "%" lv.size then "-l" else "-L"} \
-                  ${lv.size} \
+                  ${if lib.hasSuffix "%" lv.size then "${lv.size}FREE" else lv.size} \
                 -n "${lv.name}" \
                 ${lib.optionalString (lv.lvm_type == "thinlv") "--thinpool=${lv.pool}"} \
                 ${lib.optionalString (lv.lvm_type != null && lv.lvm_type != "thinlv") "--type=${lv.lvm_type}"} \


### PR DESCRIPTION
lvcreate -l does not accept a '100%' parameter which currently leads to a crash. THis change automatically changes `100%` to `100%FREE` leading to the intended behavior.
