### PR TITLE
disk-image: Fix "unexpected argument 'customQemu'" eval error

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,12 +105,13 @@ let
       hexEscapeUdevSymlink "all0these@char#acters+_are-allow.ed"
       => "all0these@char#acters+_are-allow.ed"
     */
-    hexEscapeUdevSymlink = let
-      allowedChars = "[0-9A-Za-z#+-.:=@_/]";
-      charToHex = c: lib.toHexString (lib.strings.charToInt c);
-    in
-    lib.stringAsChars
-      (c: if lib.match allowedChars c != null || c == "" then c else "\\x" + charToHex c);
+    hexEscapeUdevSymlink =
+      let
+        allowedChars = "[0-9A-Za-z#+-.:=@_/]";
+        charToHex = c: lib.toHexString (lib.strings.charToInt c);
+      in
+      lib.stringAsChars
+        (c: if lib.match allowedChars c != null || c == "" then c else "\\x" + charToHex c);
 
     /* get the index an item in a list
 
@@ -333,6 +334,14 @@ let
        packages :: lib.types.devices -> pkgs -> [ derivation ]
     */
     packages = toplevel: toplevel._packages;
+
+    /* Checks whether nixpkgs is recent enough for vmTools to support the customQemu argument.
+
+      Returns false, which is technically incorrect, for a few commits on 2024-07-08, but we can't be more accurate.
+
+      vmToolsSupportsCustomQemu :: pkgs -> bool
+    */
+    vmToolsSupportsCustomQemu = pkgs: lib.versionAtLeast pkgs.lib.version "24.11.20240709";
 
     optionTypes = rec {
       filename = lib.mkOptionType {

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -12,15 +12,19 @@ let
   checked = diskoCfg.checkScripts;
 
   configSupportsZfs = config.boot.supportedFilesystems.zfs or false;
-  vmTools = pkgs.vmTools.override {
-    rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ]
-      ++ (lib.optional configSupportsZfs "zfs")
-      ++ cfg.extraRootModules;
-    customQemu = cfg.qemu;
-    kernel = pkgs.aggregateModules
-      (with cfg.kernelPackages; [ kernel ]
-        ++ lib.optional (lib.elem "zfs" cfg.extraRootModules || configSupportsZfs) zfs);
-  };
+  vmTools = pkgs.vmTools.override
+    {
+      rootModules = [ "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ]
+        ++ (lib.optional configSupportsZfs "zfs")
+        ++ cfg.extraRootModules;
+      kernel = pkgs.aggregateModules
+        (with cfg.kernelPackages; [ kernel ]
+          ++ lib.optional (lib.elem "zfs" cfg.extraRootModules || configSupportsZfs) zfs);
+    }
+  // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu pkgs)
+    {
+      customQemu = cfg.qemu;
+    };
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig config diskoLib.testLib.devices;
   systemToInstall = extendModules {
     modules = [

--- a/module.nix
+++ b/module.nix
@@ -194,6 +194,17 @@ in
   };
 
   config = {
+    assertions = [
+      {
+        assertion = config.disko.imageBuilder.qemu != null -> diskoLib.vmToolsSupportsCustomQemu pkgs;
+        message = ''
+          You have set config.disko.imageBuild.qemu, but vmTools in your nixpkgs version "${lib.version}"
+          does not support overriding the qemu package with the customQemu option yet.
+          Please upgrade nixpkgs so that `lib.version` is at least "24.11.20240709".
+        '';
+      }
+    ];
+
     _module.args.diskoLib = import ./lib {
       inherit lib;
       rootMountPoint = config.disko.rootMountPoint;
@@ -226,8 +237,11 @@ in
 
     # we need to specify the keys here, so we don't get an infinite recursion error
     # Remember to add config keys here if they are added to types
-    fileSystems = lib.mkIf cfg.enableConfig cfg.devices._config.fileSystems or { };
-    boot = lib.mkIf cfg.enableConfig cfg.devices._config.boot or { };
-    swapDevices = lib.mkIf cfg.enableConfig cfg.devices._config.swapDevices or [ ];
+    fileSystems = lib.mkIf
+      cfg.enableConfig cfg.devices._config.fileSystems or { };
+    boot = lib.mkIf
+      cfg.enableConfig cfg.devices._config.boot or { };
+    swapDevices = lib.mkIf
+      cfg.enableConfig cfg.devices._config.swapDevices or [ ];
   };
 }


### PR DESCRIPTION
Previously, an error like

    error: function 'anonymous lambda' called with unexpected argument 'customQemu'

    at /nix/store/lbqj1cndic4121whnx8xm0jgb1c8x4xx-source/pkgs/build-support/vm/default.nix:1:1:

was printed when trying to evaluate `config.system.build.vmWithDisko` or `config.system.build.diskoImagesScript` with nixpkgs 24.05 (and below).

Fixes #850