### PR TITLE
treewide: Fix using pkgs.{build,host}Platform alias

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           default = self.packages.${system}.disko;
 
           create-release = pkgs.callPackage ./scripts/create-release.nix { };
-        } // pkgs.lib.optionalAttrs (!pkgs.buildPlatform.isRiscV64) {
+        } // pkgs.lib.optionalAttrs (!pkgs.stdenv.buildPlatform.isRiscV64) {
           disko-doc = pkgs.callPackage ./doc.nix { };
         });
       # TODO: disable bios-related tests on aarch64...
@@ -48,7 +48,7 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           # FIXME: aarch64-linux seems to hang on boot
-          nixosTests = lib.optionalAttrs pkgs.hostPlatform.isx86_64 (import ./tests {
+          nixosTests = lib.optionalAttrs pkgs.stdenv.hostPlatform.isx86_64 (import ./tests {
             inherit pkgs;
             makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
             eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
@@ -66,8 +66,8 @@
           '';
         in
         # FIXME: aarch64-linux seems to hang on boot
-        lib.optionalAttrs pkgs.hostPlatform.isx86_64 (nixosTests // { inherit disko-install; }) //
-        pkgs.lib.optionalAttrs (!pkgs.buildPlatform.isRiscV64 && !pkgs.hostPlatform.isx86_32) {
+        lib.optionalAttrs pkgs.stdenv.hostPlatform.isx86_64 (nixosTests // { inherit disko-install; }) //
+        pkgs.lib.optionalAttrs (!pkgs.stdenv.buildPlatform.isRiscV64 && !pkgs.stdenv.hostPlatform.isx86_32) {
           inherit shellcheck;
           inherit (self.packages.${system}) disko-doc;
         });

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -287,7 +287,7 @@ let
     */
     writeCheckedBash = { pkgs, checked ? false, noDeps ? false }: pkgs.writers.makeScriptWriter {
       interpreter = if noDeps then "/usr/bin/env bash" else "${pkgs.bash}/bin/bash";
-      check = lib.optionalString (checked && !pkgs.hostPlatform.isRiscV64 && !pkgs.hostPlatform.isx86_32) (pkgs.writeScript "check" ''
+      check = lib.optionalString (checked && !pkgs.stdenv.hostPlatform.isRiscV64 && !pkgs.stdenv.hostPlatform.isx86_32) (pkgs.writeScript "check" ''
         set -efu
         # SC2054: our toShellVars function doesn't quote list elements with commas
         # SC2034: We don't use all variables exported by hooks.

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -50,7 +50,7 @@ let
       , bootCommands ? ""
       , extraInstallerConfig ? { }
       , extraSystemConfig ? { }
-      , efi ? !pkgs.hostPlatform.isRiscV64
+      , efi ? !pkgs.stdenv.hostPlatform.isRiscV64
       , postDisko ? ""
       , testMode ? "module" # can be one of direct module cli
       , testBoot ? true # if we actually want to test booting or just create/mount

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -12,7 +12,7 @@ let
         (x: lib.hasSuffix ".nix" x && x != "default.nix")
         (lib.attrNames (builtins.readDir ./.))
     );
-  incompatibleTests = lib.optionals pkgs.buildPlatform.isRiscV64 [ "zfs" "zfs-over-legacy" "cli" "module" "complex" ];
+  incompatibleTests = lib.optionals pkgs.stdenv.buildPlatform.isRiscV64 [ "zfs" "zfs-over-legacy" "cli" "module" "complex" ];
   allCompatibleFilenames = lib.subtractLists incompatibleTests allTestFilenames;
 
   allTests = lib.genAttrs allCompatibleFilenames (test: import (./. + "/${test}.nix") { inherit diskoLib pkgs; });


### PR DESCRIPTION
This was recently changed in nixpkgs to be an alias; if nixpkgs is configured to disable aliases, this usage will fail.