### PR TITLE
cli: Fix legacy aliases

### DIFF
--- a/disko
+++ b/disko
@@ -181,6 +181,11 @@ if [[ $mode = "destroy,format,mount" && $skip_destroy_safety_check = true ]]; th
   command+=("--yes-wipe-all-disks")
 fi
 
+# Legacy modes don't support --yes-wipe-all-disks and are not in `$script/bin`
+if [[ $mode = "disko" ]] || [[ $mode = "create" ]] || [[ $mode = "zap_create_mount" ]] ; then
+  command=("$script")
+fi
+
 if [[ -n "${dry_run+x}" ]]; then
   echo "${command[@]}"
 else


### PR DESCRIPTION
Fixes regression introduced in daca7be3092f253e5a3c9ce059d5a0225de6902d that would cause the following behavior:

    $ ./disko --mode disko --dry-run example/simple-efi.nix
    /nix/store/syiv3fhzd7ar2nk5pbh56gswcs4fzvxs-disko/bin/*

Now, it returns the correct script path again:

    $ ./disko --mode disko --dry-run example/simple-efi.nix
    /nix/store/syiv3fhzd7ar2nk5pbh56gswcs4fzvxs-disko