### PR TITLE
destroy: Fix shellcheck warning in nixos 24.05

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -556,7 +556,7 @@ let
                 if [ "$1" != "--yes-wipe-all-disks" ]; then
                   echo "WARNING: This will destroy all data on the disks defined in disko.devices, which are:"
                   echo
-                  # shellcheck disable=SC2043
+                  # shellcheck disable=SC2043,2041
                   for dev in ${selectedDisks}; do
                     echo "  - $dev"
                   done


### PR DESCRIPTION
Regression introduced in 94bc0f5bb0dff8b98597f1eb66a7156469932221, because I developed against unstable, which has https://github.com/NixOS/nixpkgs/pull/333744 merged, while 24.05 doesn't.

Partly shellchecks mistake, see https://github.com/koalaman/shellcheck/issues/2891 but whatever, we can't do much more about it than ignore the warning.

Fixes #868