### PR TITLE
module: expose tests.bootCommands and tests.enableOCR

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -171,6 +171,14 @@ in
         default = config.boot.loader.systemd-boot.enable || config.boot.loader.grub.efiSupport;
       };
 
+      enableOCR = lib.mkOption {
+        description = ''
+          Sets the enableOCR option in the NixOS VM test driver.
+        '';
+        type = lib.types.bool;
+        default = false;
+      };
+
       extraChecks = lib.mkOption {
         description = ''
           extra checks to run in the `system.build.installTest`.
@@ -236,6 +244,7 @@ in
           testMode = "direct";
           bootCommands = cfg.tests.bootCommands;
           efi = cfg.tests.efi;
+          enableOCR = cfg.tests.enableOCR;
           extraSystemConfig = cfg.tests.extraConfig;
           extraTestScript = cfg.tests.extraChecks;
         };

--- a/module.nix
+++ b/module.nix
@@ -153,6 +153,14 @@ in
     };
 
     tests = {
+      bootCommands = lib.mkOption {
+        description = ''
+          NixOS test script commands to run after the machine has started. Can
+          be used to enter an interactive password.
+        '';
+        type = lib.types.lines;
+      };
+
       efi = lib.mkOption {
         description = ''
           Whether efi is enabled for the `system.build.installTest`.
@@ -226,6 +234,7 @@ in
           name = "${config.networking.hostName}-disko";
           disko-config = builtins.removeAttrs config [ "_module" ];
           testMode = "direct";
+          bootCommands = cfg.tests.bootCommands;
           efi = cfg.tests.efi;
           extraSystemConfig = cfg.tests.extraConfig;
           extraTestScript = cfg.tests.extraChecks;


### PR DESCRIPTION
This makes it possible to e.g. run `installTest` for configs that need interactive input. See individual commits for details.