### PR TITLE
ZFS: Add log, spare & dedup vdev types, support multiple special vdevs, fix bug with mixed vdev types

### DIFF
--- a/example/zfs-with-vdevs.nix
+++ b/example/zfs-with-vdevs.nix
@@ -1,9 +1,9 @@
 {
   disko.devices = {
     disk = {
-      x = {
+      data1 = {
         type = "disk";
-        device = "/dev/sdx";
+        device = "/dev/vda";
         content = {
           type = "gpt";
           partitions = {
@@ -27,9 +27,9 @@
           };
         };
       };
-      y = {
+      data2 = {
         type = "disk";
-        device = "/dev/sdy";
+        device = "/dev/vdb";
         content = {
           type = "gpt";
           partitions = {
@@ -43,7 +43,7 @@
           };
         };
       };
-      spare = {
+      data3 = {
         type = "disk";
         device = "/dev/vdc";
         content = {
@@ -59,7 +59,7 @@
           };
         };
       };
-      log = {
+      spare = {
         type = "disk";
         device = "/dev/vdd";
         content = {
@@ -75,7 +75,7 @@
           };
         };
       };
-      dedup = {
+      log1 = {
         type = "disk";
         device = "/dev/vde";
         content = {
@@ -91,7 +91,7 @@
           };
         };
       };
-      special = {
+      log2 = {
         type = "disk";
         device = "/dev/vdf";
         content = {
@@ -107,9 +107,121 @@
           };
         };
       };
-      cache = {
+      log3 = {
         type = "disk";
         device = "/dev/vdg";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      dedup1 = {
+        type = "disk";
+        device = "/dev/vdh";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      dedup2 = {
+        type = "disk";
+        device = "/dev/vdi";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      dedup3 = {
+        type = "disk";
+        device = "/dev/vdj";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      special1 = {
+        type = "disk";
+        device = "/dev/vdk";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      special2 = {
+        type = "disk";
+        device = "/dev/vdl";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      special3 = {
+        type = "disk";
+        device = "/dev/vdm";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      cache = {
+        type = "disk";
+        device = "/dev/vdn";
         content = {
           type = "gpt";
           partitions = {
@@ -133,26 +245,38 @@
             vdev = [
               {
                 mode = "mirror";
-                members = [
-                  "x"
-                  "y"
-                ];
+                members = [ "data1" "data2" ];
+              }
+              {
+                members = [ "data3" ];
               }
             ];
             spare = [ "spare" ];
             log = [
               {
-                members = [ "log" ];
+                mode = "mirror";
+                members = [ "log1" "log2" ];
+              }
+              {
+                members = [ "log3" ];
               }
             ];
             dedup = [
               {
-                members = [ "dedup" ];
+                mode = "mirror";
+                members = [ "dedup1" "dedup2" ];
+              }
+              {
+                members = [ "dedup3" ];
               }
             ];
             special = [
               {
-                members = [ "special" ];
+                mode = "mirror";
+                members = [ "special1" "special2" ];
+              }
+              {
+                members = [ "special3" ];
               }
             ];
             cache = [ "cache" ];

--- a/example/zfs-with-vdevs.nix
+++ b/example/zfs-with-vdevs.nix
@@ -43,9 +43,57 @@
           };
         };
       };
-      z = {
+      spare = {
         type = "disk";
-        device = "/dev/sdz";
+        device = "/dev/vdc";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      log = {
+        type = "disk";
+        device = "/dev/vdd";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      dedup = {
+        type = "disk";
+        device = "/dev/vde";
+        content = {
+          type = "gpt";
+          partitions = {
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+      special = {
+        type = "disk";
+        device = "/dev/vdf";
         content = {
           type = "gpt";
           partitions = {
@@ -61,7 +109,7 @@
       };
       cache = {
         type = "disk";
-        device = "/dev/vdc";
+        device = "/dev/vdg";
         content = {
           type = "gpt";
           partitions = {
@@ -91,9 +139,22 @@
                 ];
               }
             ];
-            special = {
-              members = [ "z" ];
-            };
+            spare = [ "spare" ];
+            log = [
+              {
+                members = [ "log" ];
+              }
+            ];
+            dedup = [
+              {
+                members = [ "dedup" ];
+              }
+            ];
+            special = [
+              {
+                members = [ "special" ];
+              }
+            ];
             cache = [ "cache" ];
           };
         };

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -38,7 +38,23 @@ let
       };
 
     # list of devices generated inside qemu
-    devices = [ "/dev/vda" "/dev/vdb" "/dev/vdc" "/dev/vdd" "/dev/vde" "/dev/vdf" "/dev/vdg" "/dev/vdh" ];
+    devices = [
+      "/dev/vda"
+      "/dev/vdb"
+      "/dev/vdc"
+      "/dev/vdd"
+      "/dev/vde"
+      "/dev/vdf"
+      "/dev/vdg"
+      "/dev/vdh"
+      "/dev/vdi"
+      "/dev/vdj"
+      "/dev/vdk"
+      "/dev/vdl"
+      "/dev/vdm"
+      "/dev/vdn"
+      "/dev/vdo"
+    ];
 
     # This is the test generator for a disko test
     makeDiskoTest =

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -38,7 +38,7 @@ let
       };
 
     # list of devices generated inside qemu
-    devices = [ "/dev/vda" "/dev/vdb" "/dev/vdc" "/dev/vdd" "/dev/vde" "/dev/vdf" ];
+    devices = [ "/dev/vda" "/dev/vdb" "/dev/vdc" "/dev/vdd" "/dev/vde" "/dev/vdf" "/dev/vdg" "/dev/vdh" ];
 
     # This is the test generator for a disko test
     makeDiskoTest =

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -1,6 +1,6 @@
 { config, options, lib, diskoLib, rootMountPoint, ... }:
 let
-  # TODO: Consider expanding to handle `disk` `file` and `draid` mode options.
+  # TODO: Consider expanding to handle `file` and `draid` mode options.
   modeOptions = [
     ""
     "mirror"
@@ -167,7 +167,9 @@ in
             }")
           '';
           formatVdev = type: vdev: formatOutput type vdev.mode vdev.members;
-          formatVdevList = type: vdevs: lib.concatMapStrings (formatVdev type) vdevs;
+          formatVdevList = type: vdevs: lib.concatMapStrings
+            (formatVdev type)
+            (builtins.sort (a: b: a.mode < b.mode) vdevs);
           hasTopology = !(builtins.isString config.mode);
           mode = if hasTopology then "prescribed" else config.mode;
           topology = lib.optionalAttrs hasTopology config.mode.topology;

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -169,7 +169,7 @@ in
           formatVdev = type: vdev: formatOutput type vdev.mode vdev.members;
           formatVdevList = type: vdevs: lib.concatMapStrings
             (formatVdev type)
-            (builtins.sort (a: b: a.mode < b.mode) vdevs);
+            (builtins.sort (a: _: a.mode == "") vdevs);
           hasTopology = !(builtins.isString config.mode);
           mode = if hasTopology then "prescribed" else config.mode;
           topology = lib.optionalAttrs hasTopology config.mode.topology;

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -63,10 +63,15 @@ in
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#Virtual_Devices_(vdevs)
                         for details.
                       '';
-                      example = [{
-                        mode = "mirror";
-                        members = [ "x" "y" "/dev/sda1" ];
-                      }];
+                      example = [
+                        {
+                          mode = "mirror";
+                          members = [ "x" "y" ];
+                        }
+                        {
+                          members = [ "z" ];
+                        }
+                      ];
                     };
                     spare = lib.mkOption {
                       type = lib.types.listOf lib.types.str;
@@ -76,6 +81,7 @@ in
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#Hot_Spares
                         for details.
                       '';
+                      example = [ "x" "y" ];
                     };
                     log = lib.mkOption {
                       type = lib.types.listOf vdev;
@@ -85,6 +91,15 @@ in
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#Intent_Log
                         for details.
                       '';
+                      example = [
+                        {
+                          mode = "mirror";
+                          members = [ "x" "y" ];
+                        }
+                        {
+                          members = [ "z" ];
+                        }
+                      ];
                     };
                     dedup = lib.mkOption {
                       type = lib.types.listOf vdev;
@@ -94,6 +109,15 @@ in
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#dedup
                         for details.
                       '';
+                      example = [
+                        {
+                          mode = "mirror";
+                          members = [ "x" "y" ];
+                        }
+                        {
+                          members = [ "z" ];
+                        }
+                      ];
                     };
                     special = lib.mkOption {
                       type = lib.types.either (lib.types.listOf vdev) (lib.types.nullOr vdev);
@@ -103,6 +127,15 @@ in
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#special
                         for details.
                       '';
+                      example = [
+                        {
+                          mode = "mirror";
+                          members = [ "x" "y" ];
+                        }
+                        {
+                          members = [ "z" ];
+                        }
+                      ];
                     };
                     cache = lib.mkOption {
                       type = lib.types.listOf lib.types.str;
@@ -112,6 +145,7 @@ in
                         https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#Cache_Devices
                         for details.
                       '';
+                      example = [ "x" "y" ];
                     };
                   };
                 });

--- a/tests/zfs-with-vdevs.nix
+++ b/tests/zfs-with-vdevs.nix
@@ -38,5 +38,40 @@ diskoLib.testLib.makeDiskoTest {
     assert_property("zroot/zfs_fs", "com.sun:auto-snapshot", "true")
     assert_property("zroot/zfs_fs", "compression", "zstd")
     machine.succeed("mountpoint /zfs_fs");
+
+    # Take the status output and flatten it so that each device is on a single line prefixed with with the group (either
+    # the pool name or a designation like log/cache/spare/dedup/special) and first portion of the vdev name (empty for a
+    # disk from a single vdev, mirror for devices in a mirror. This makes it easy to verify that the layout is as
+    # expected.
+    group = ""
+    vdev = ""
+    actual = []
+    for line in machine.succeed("zpool status -P zroot").split("\n"):
+        first_word = line.strip().split(" ", 1)[0]
+        if line.startswith("\t  ") and first_word.startswith("/"):
+            actual.append(f"{group}{vdev}{first_word}")
+        elif line.startswith("\t  "):
+            vdev = f"{first_word.split('-', 1)[0]} "
+        elif line.startswith("\t"):
+            group = f"{first_word} "
+            vdev = ""
+    actual.sort()
+    expected=sorted([
+      'zroot /dev/disk/by-partlabel/disk-data3-zfs',
+      'zroot mirror /dev/disk/by-partlabel/disk-data1-zfs',
+      'zroot mirror /dev/disk/by-partlabel/disk-data2-zfs',
+      'dedup /dev/disk/by-partlabel/disk-dedup3-zfs',
+      'dedup mirror /dev/disk/by-partlabel/disk-dedup1-zfs',
+      'dedup mirror /dev/disk/by-partlabel/disk-dedup2-zfs',
+      'special /dev/disk/by-partlabel/disk-special3-zfs',
+      'special mirror /dev/disk/by-partlabel/disk-special1-zfs',
+      'special mirror /dev/disk/by-partlabel/disk-special2-zfs',
+      'logs /dev/disk/by-partlabel/disk-log3-zfs',
+      'logs mirror /dev/disk/by-partlabel/disk-log1-zfs',
+      'logs mirror /dev/disk/by-partlabel/disk-log2-zfs',
+      'cache /dev/disk/by-partlabel/disk-cache-zfs',
+      'spares /dev/disk/by-partlabel/disk-spare-zfs',
+    ])
+    assert actual == expected, f"Incorrect pool layout. Expected:\n\t{'\n\t'.join(expected)}\nActual:\n\t{'\n\t'.join(actual)}"
   '';
 }


### PR DESCRIPTION
This adds support for the missing categories of devices: `log`, `spare`, and `dedup`.

`log` & `dedup` can each have multiple vdevs assigned (the workload will be load-balanced over these), so these accept a list of vdev configurations. This is actually also true for `special`, but the existing implementation only supported a single vdev. This has been updated to accept either a list of vdevs (like the other two), or a single vdev (for backwards compatibility).

`spare` (like `cache`) just takes a list of device names, neither type supports more complicated vdevs like mirrors.

---

While testing this I ran into a bug that affected all types which support having multiple vdevs (which includes the regular data vdevs). The following topology config:

```nix
{
  vdev = [
    {
      mode = "mirror";
      members = [ "data1" "data2" ];
    }
    {
      members = [ "data3" ];
    }
  ];
}
```
 
would result in the following command:

```shell
zpool create -f <name> mirror /dev/data1 /dev/data2 /dev/data3
```

which would result in a single vdev with a 3-way mirror, rather than a vdev with a 2-way mirror and a second vdev with a single disk. As far as I could find there is no keyword to indicate "mirror config ended, next is a vdev made up of a single disk" (which kinda makes sense given that ZFS would reject such a setup without the `-f` flag), so to fix this I added a sort so that the vdevs with an empty mode are moved to the start. This means the above config will now result in the following command:

```shell
zpool create -f <name> /dev/data3 mirror /dev/data1 /dev/data2
```

(An alternative would have been to instead generate a `zpool add` command for each vdev, but that would be a larger change, and we'd need to start handling partial successes so I opted not to at this point. Doing that would also be a step towards handing making changes to an existing pool such as adding a vdev, so it might be worth considering at some point.)

I extended the `zfs-with-vdevs` example to have this 3-device setup for each of the types that support it so that this is tested, which results in the following pool (which is also validated in the tests):

```
  pool: zroot
 state: ONLINE
config:

        NAME                   STATE     READ WRITE CKSUM
        zroot                  ONLINE       0     0     0
          disk-data3-zfs       ONLINE       0     0     0
          mirror-1             ONLINE       0     0     0
            disk-data1-zfs     ONLINE       0     0     0
            disk-data2-zfs     ONLINE       0     0     0
        dedup   
          disk-dedup3-zfs      ONLINE       0     0     0
          mirror-5             ONLINE       0     0     0
            disk-dedup1-zfs    ONLINE       0     0     0
            disk-dedup2-zfs    ONLINE       0     0     0
        special 
          disk-special3-zfs    ONLINE       0     0     0
          mirror-7             ONLINE       0     0     0
            disk-special1-zfs  ONLINE       0     0     0
            disk-special2-zfs  ONLINE       0     0     0
        logs    
          disk-log3-zfs        ONLINE       0     0     0
          mirror-3             ONLINE       0     0     0
            disk-log1-zfs      ONLINE       0     0     0
            disk-log2-zfs      ONLINE       0     0     0
        cache
          disk-cache-zfs       ONLINE       0     0     0
        spares
          disk-spare-zfs       AVAIL   
```