### PR TITLE
Fix examples/zfs-over-legacy.nix

### DIFF
--- a/example/zfs-over-legacy.nix
+++ b/example/zfs-over-legacy.nix
@@ -48,6 +48,7 @@
           "root/zfs_fs" = {
             type = "zfs_fs";
             mountpoint = "/zfs_fs";
+            options.mountpoint = "legacy";
             options."com.sun:auto-snapshot" = "true";
           };
         };


### PR DESCRIPTION
Shouldn't the legacy example have `options.mountpoint = "legacy"`?