### PR TITLE
Fix evaluation when a GPT partition is left unformatted

### DIFF
--- a/example/gpt-unformatted.nix
+++ b/example/gpt-unformatted.nix
@@ -1,0 +1,36 @@
+# Example to create a GPT partition but doesn't format it
+{
+  disko.devices = {
+    disk = {
+      main = {
+        device = "/dev/vdb";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              type = "EF00";
+              size = "100M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            empty = {
+              size = "1G";
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -26,7 +26,7 @@ in
               lib.types.either
                 (lib.types.strMatching (hexPattern 4))
                 (lib.types.strMatching (lib.concatMapStringsSep "-" hexPattern [ 8 4 4 4 12 ]));
-            default = if partition.config.content.type == "swap" then "8200" else "8300";
+            default = if partition.config.content != null && partition.config.content.type == "swap" then "8200" else "8300";
             defaultText = ''8300 (Linux filesystem) normally, 8200 (Linux swap) if content.type is "swap"'';
             description = ''
               Filesystem type to use.

--- a/tests/gpt-unformatted.nix
+++ b/tests/gpt-unformatted.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "gpt-unformatted";
+  disko-config = ../example/gpt-unformatted.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+  '';
+}


### PR DESCRIPTION
Since dcabccaad6, if `content` is not specified, it will generate a confusing error "value is null while a set was expected". This changes disko back to its old behaviour in this specific case (i.e. defaulting to 8300 for an unformatted partition).