### PR TITLE
make-disk-image: Compare against correct nixpkgs version

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -340,10 +340,11 @@ let
     /* Checks whether nixpkgs is recent enough for vmTools to support the customQemu argument.
 
       Returns false, which is technically incorrect, for a few commits on 2024-07-08, but we can't be more accurate.
+      Make sure to pass lib, not pkgs.lib! See https://github.com/nix-community/disko/issues/904
 
-      vmToolsSupportsCustomQemu :: pkgs -> bool
+      vmToolsSupportsCustomQemu :: final_lib -> bool
     */
-    vmToolsSupportsCustomQemu = pkgs: lib.versionAtLeast pkgs.lib.version "24.11.20240709";
+    vmToolsSupportsCustomQemu = final_lib: lib.versionAtLeast final_lib.version "24.11.20240709";
 
     optionTypes = rec {
       filename = lib.mkOptionType {

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -21,7 +21,7 @@ let
         (with cfg.kernelPackages; [ kernel ]
           ++ lib.optional (lib.elem "zfs" cfg.extraRootModules || configSupportsZfs) zfs);
     }
-  // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu pkgs)
+  // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu lib)
     {
       customQemu = cfg.qemu;
     };

--- a/module.nix
+++ b/module.nix
@@ -213,7 +213,7 @@ in
   config = {
     assertions = [
       {
-        assertion = config.disko.imageBuilder.qemu != null -> diskoLib.vmToolsSupportsCustomQemu pkgs;
+        assertion = config.disko.imageBuilder.qemu != null -> diskoLib.vmToolsSupportsCustomQemu lib;
         message = ''
           You have set config.disko.imageBuild.qemu, but vmTools in your nixpkgs version "${lib.version}"
           does not support overriding the qemu package with the customQemu option yet.


### PR DESCRIPTION
It seems that there is a difference between how `pkgs` and `lib` get passed to NixOS modules: `pkgs` is the unmodified original, `lib` is the final version after overrides etc.

This causes `pkgs.lib.version` to be `24.11git` in some cases, while `lib.version` is `24.11.20241123.0c58267`.
Maybe this can be fixed in nixpkgs? Either way, this change fixes that issue.

Fixes #904