### PR TITLE
disk-image: Fix compatibility with nixpkgs unstable

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -201,7 +201,7 @@ in
         done
         ${installer}
       ''}
-      echo "export origBuilder=$origBuilder" > xchg/saved-env
+      echo "export origBuilder=$origBuilder" >> xchg/saved-env
       ${preVM}
     ''}
     export postVM=${diskoLib.writeCheckedBash { inherit pkgs checked; } "postVM.sh" postVM}


### PR DESCRIPTION
Fixes #900

This was caused by https://github.com/NixOS/nixpkgs/pull/354535 originally. The breaking changes introduced there have been resolved by https://github.com/NixOS/nixpkgs/pull/360413, but one addition survived, which was the line `source $stdenv/setup`.

Because we used `>` instead of `>>`, `saved-env` was overwritten, so even with the second PR, the script failed with the following error:

    /nix/store/pw...ykc-vm-run-stage2: line 16: stdenv: unbound variable

Once this and the second PR mentioned above are merged, #903 will be unblocked.