### PR TITLE
tree-wide: Remove all uses of lib.mdDoc

### DIFF
--- a/lib/types/btrfs.nix
+++ b/lib/types/btrfs.nix
@@ -17,7 +17,7 @@ let
         priority = lib.mkOption {
           type = lib.types.nullOr lib.types.int;
           default = null;
-          description = lib.mdDoc ''
+          description = ''
             Specify the priority of the swap file. Priority is a value between 0 and 32767.
             Higher numbers indicate higher priority.
             null lets the kernel choose a priority, which will show up as a negative value.

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -15,7 +15,7 @@
       default = null;
       example = "once";
       type = lib.types.nullOr (lib.types.enum [ "once" "pages" "both" ]);
-      description = lib.mdDoc ''
+      description = ''
         Specify the discard policy for the swap device. If "once", then the
         whole swap space is discarded at swapon invocation. If "pages",
         asynchronous discard on freed pages is performed, before returning to
@@ -37,7 +37,7 @@
     priority = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Specify the priority of the swap device. Priority is a value between 0 and 32767.
         Higher numbers indicate higher priority.
         null lets the kernel choose a priority, which will show up as a negative value.


### PR DESCRIPTION
This was deprecated in 24.05 already, and removed in 24.11.

Fixes build of `jsonTypes` in #903 