### PR TITLE
make-disk-image: improve xargs invocation

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -101,7 +101,7 @@ let
 
     # We copy files with cp because `nix copy` seems to have a large memory leak
     mkdir -p ${systemToInstall.config.disko.rootMountPoint}/nix/store
-    xargs -P 0 ${cpEarlyExit} < ${closureInfo}/store-paths
+    xargs ${cfg.xargsFlags} ${cpEarlyExit} < ${closureInfo}/store-paths
 
     ${systemToInstall.config.system.build.nixos-install}/bin/nixos-install --root ${systemToInstall.config.disko.rootMountPoint} --system ${systemToInstall.config.system.build.toplevel} --keep-going --no-channel-copy -v --no-root-password --option binary-caches ""
     umount -Rv ${systemToInstall.config.disko.rootMountPoint}

--- a/module.nix
+++ b/module.nix
@@ -102,6 +102,13 @@ in
         description = "QEMU image format to use for the disk images";
         default = "raw";
       };
+
+      xargsFlags = lib.mkOption {
+        type = lib.types.str;
+        description = "flags for xargs invocation";
+        default = "";
+        example = "-L 100 -P 0";
+      };
     };
 
     memSize = lib.mkOption {


### PR DESCRIPTION
When the disk image is too small, `cp` fails because it is out of space. However, `xargs` does not abort immediately but still invokes all remaining `cp` commands, which will of course also fail. That can lead to long waiting times until the make-disk-image script exits with a failure. This PR decreases the time to failure by letting `xargs` abort directly by causing `cp` to fail with exti code 255. 

https://www.man7.org/linux/man-pages/man1/xargs.1.html#DESCRIPTION
```
       If any invocation of the command exits with a status of 255,
       xargs will stop immediately without reading any further input.
       An error message is issued on stderr when this happens.
```

Additionally allow `xargs` to invoke `cp` `nproc` times in parallel with `-P 0` as argument. Since by default the vm uses only one core, this does not change anything. However, for custom `imageBuilder.qemu` options like `-smp 4` this can cause a major speedup. For example, I observed a time reduction from 22 to 12 minutes when building an image with aarch64 binfmt emulation.