### PR TITLE
fix: Apply umask=0077 to /boot partition in all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A simple disko configuration may look like this:
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             root = {

--- a/docs/table-to-gpt.md
+++ b/docs/table-to-gpt.md
@@ -42,6 +42,7 @@ for example like this:
             type = "filesystem";
             format = "vfat";
             mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
           };
         }
         {

--- a/example/boot-raid1.nix
+++ b/example/boot-raid1.nix
@@ -67,6 +67,7 @@
           type = "filesystem";
           format = "vfat";
           mountpoint = "/boot";
+          mountOptions = [ "umask=0077" ];
         };
       };
       raid1 = {

--- a/example/gpt-name-with-whitespace.nix
+++ b/example/gpt-name-with-whitespace.nix
@@ -14,6 +14,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             "name with spaces" = {

--- a/example/gpt-unformatted.nix
+++ b/example/gpt-unformatted.nix
@@ -15,6 +15,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             };
             empty = {

--- a/example/legacy-table-with-whitespace.nix
+++ b/example/legacy-table-with-whitespace.nix
@@ -17,6 +17,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             }
             {

--- a/example/legacy-table.nix
+++ b/example/legacy-table.nix
@@ -17,6 +17,7 @@
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
               };
             }
             {

--- a/example/luks-on-mdadm.nix
+++ b/example/luks-on-mdadm.nix
@@ -37,6 +37,7 @@
         type = "filesystem";
         format = "vfat";
         mountpoint = "/boot";
+        mountOptions = [ "umask=0077" ];
       };
     };
     raid1 = {

--- a/example/lvm-raid.nix
+++ b/example/lvm-raid.nix
@@ -59,6 +59,7 @@
           type = "filesystem";
           format = "vfat";
           mountpoint = "/boot";
+          mountOptions = [ "umask=0077" ];
         };
       };
     };


### PR DESCRIPTION
Most of the examples already have it, but not all of them and I already ran into this problem multiple times when copying example configs.