### PR TITLE
make-disk-image: fix function precedence breaks customQemu

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -13,7 +13,7 @@ let
 
   configSupportsZfs = config.boot.supportedFilesystems.zfs or false;
   vmTools = pkgs.vmTools.override
-    {
+    ({
       rootModules = [
         "9p" "9pnet_virtio" # we can drop those in future if we stop supporting 24.11
 
@@ -32,7 +32,7 @@ let
   // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu lib)
     {
       customQemu = cfg.qemu;
-    };
+    });
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig config diskoLib.testLib.devices;
   systemToInstall = extendModules {
     modules = [


### PR DESCRIPTION
Function application has higher precedence than the // operator in Nix, so override is called on the main attrset before //, and the derivation does not reflect the customQemu value.