### PR TITLE
fix eval of `zfs_volume`'s `_unmount` if `content` is `null`

### DIFF
--- a/example/zfs.nix
+++ b/example/zfs.nix
@@ -81,6 +81,10 @@
               mountpoint = "/ext4onzfs";
             };
           };
+          zfs_volume_no_content = {
+            type = "zfs_volume";
+            size = "10M";
+          };
           zfs_encryptedvolume = {
             type = "zfs_volume";
             size = "10M";

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -88,7 +88,7 @@
           ${config.content._unmount.dev or ""}
         '';
 
-        fs = config.content._unmount.fs;
+        fs = config.content._unmount.fs or {};
       };
     };
     _config = lib.mkOption {


### PR DESCRIPTION
The `_unmount` attribute for `zfs_volume`s fails to evaluate if `content` is `null`; line 91 is missing a `or {}` at the end:

https://github.com/nix-community/disko/blob/f720e64ec37fa16ebba6354eadf310f81555cc07/lib/types/zfs_volume.nix#L82-L93

This PR fixes that. 

It also adds a no-content zfs volume to `example/zfs.nix` as a step towards testing for this issue, but the `_unmount` attribute is not yet evaluated as part of the tests. I am not sure what's a good way to include that evaluation in the tests. I ran into the issue while evaluating `system.build.installTest`; making sure this evaluates for all the test machines sounds reasonable to me, but I haven't added it to keep this fix small and straight-forward.

Breaking commit form git blame: d8f3cfc582356736eac3c46164cfc11a31aa082b