### PR TITLE
Add configration option for partition UUIDs

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -28,6 +28,7 @@
           type = "gpt";
           partitions = {
             luks = {
+              uuid = "f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0";
               start = "1M";
               size = "100%";
               content = {

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -210,7 +210,7 @@ in
         if ! blkid "${config.device}" >&2; then
           sgdisk --clear "${config.device}"
         fi
-        ${lib.concatStrings (map (partition:
+        ${lib.concatMapStrings (partition:
           let
             args = ''
               --partition-guid="${toString partition._index}:${if partition.uuid == null then "R" else partition.uuid}" \
@@ -234,7 +234,7 @@ in
               udevadm trigger --subsystem-match=block
               udevadm settle
             ''
-        ) sortedPartitions)}
+        ) sortedPartitions}
 
         ${
           lib.optionalString (sortedHybridPartitions != [])

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -38,7 +38,7 @@ in
             type = lib.types.str;
             default =
               if partition.config.uuid != null then
-                "/dev/disk/by-partuuid/${diskoLib.hexEscapeUdevSymlink partition.config.uuid}"
+                "/dev/disk/by-partuuid/${partition.config.uuid}"
               else if config._parent.type == "mdadm" then
                 # workaround because mdadm partlabel do not appear in /dev/disk/by-partlabel
                 "/dev/disk/by-id/md-name-any:${config._parent.name}-part${toString partition.config._index}"
@@ -46,7 +46,7 @@ in
                 "/dev/disk/by-partlabel/${diskoLib.hexEscapeUdevSymlink partition.config.label}";
             defaultText = ''
               if `uuid` is provided:
-                /dev/disk/by-partuuid/''${diskoLib.hexEscapeUdevSymlink partition.config.uuid}
+                /dev/disk/by-partuuid/''${partition.config.uuid}
 
               otherwise, if the parent is an mdadm device:
                 /dev/disk/by-id/md-name-any:''${config._parent.name}-part''${toString partition.config._index}
@@ -80,13 +80,14 @@ in
             default = name;
           };
           uuid = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
+            type = lib.types.nullOr (lib.types.strMatching "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}");
             default = null;
+            defaultText = "`null` - generate a UUID when creating the partition";
             example = "809b3a2b-828a-4730-95e1-75b6343e415a";
             description = ''
               The UUID (also known as GUID) of the partition. Note that this is distinct from the UUID of the filesystem.
 
-              If none is provided, a random UUID will be generated when creating the partition.
+              You can generate a UUID with the command `uuidgen -r`.
             '';
           };
           label = lib.mkOption {

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -37,13 +37,18 @@ in
           device = lib.mkOption {
             type = lib.types.str;
             default =
-              if config._parent.type == "mdadm" then
-              # workaround because mdadm partlabel do not appear in /dev/disk/by-partlabel
+              if partition.config.uuid != null then
+                "/dev/disk/by-partuuid/${diskoLib.hexEscapeUdevSymlink partition.config.uuid}"
+              else if config._parent.type == "mdadm" then
+                # workaround because mdadm partlabel do not appear in /dev/disk/by-partlabel
                 "/dev/disk/by-id/md-name-any:${config._parent.name}-part${toString partition.config._index}"
               else
                 "/dev/disk/by-partlabel/${diskoLib.hexEscapeUdevSymlink partition.config.label}";
             defaultText = ''
-              if the parent is an mdadm device:
+              if `uuid` is provided:
+                /dev/disk/by-partuuid/''${diskoLib.hexEscapeUdevSymlink partition.config.uuid}
+
+              otherwise, if the parent is an mdadm device:
                 /dev/disk/by-id/md-name-any:''${config._parent.name}-part''${toString partition.config._index}
 
               otherwise:
@@ -73,6 +78,16 @@ in
             type = lib.types.str;
             description = "Name of the partition";
             default = name;
+          };
+          uuid = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "809b3a2b-828a-4730-95e1-75b6343e415a";
+            description = ''
+              The UUID (also known as GUID) of the partition. Note that this is distinct from the UUID of the filesystem.
+
+              If none is provided, a random UUID will be generated when creating the partition.
+            '';
           };
           label = lib.mkOption {
             type = lib.types.str;
@@ -195,24 +210,31 @@ in
         if ! blkid "${config.device}" >&2; then
           sgdisk --clear "${config.device}"
         fi
-        ${lib.concatStrings (map (partition: ''
-          # try to create the partition, if it fails, try to change the type and name
-          if ! sgdisk \
-            --align-end ${lib.optionalString (partition.alignment != 0) ''--set-alignment=${builtins.toString partition.alignment}''} \
-            --new=${toString partition._index}:${partition.start}:${partition.end} \
-            --change-name="${toString partition._index}:${partition.label}" \
-            --typecode=${toString partition._index}:${partition.type} \
-            "${config.device}"
-          then sgdisk \
-            --change-name="${toString partition._index}:${partition.label}" \
-            --typecode=${toString partition._index}:${partition.type} \
-            "${config.device}"
-          fi
-          # ensure /dev/disk/by-path/..-partN exists before continuing
-          partprobe "${config.device}" || : # sometimes partprobe fails, but the partitions are still up2date
-          udevadm trigger --subsystem-match=block
-          udevadm settle
-        '') sortedPartitions)}
+        ${lib.concatStrings (map (partition:
+          let
+            args = ''
+              --partition-guid="${toString partition._index}:${if partition.uuid == null then "R" else partition.uuid}" \
+              --change-name="${toString partition._index}:${partition.label}" \
+              --typecode=${toString partition._index}:${partition.type} \
+              "${config.device}" \
+            '';
+            createArgs = ''
+              --align-end ${lib.optionalString (partition.alignment != 0) ''--set-alignment=${builtins.toString partition.alignment}''} \
+              --new=${toString partition._index}:${partition.start}:${partition.end} \
+            '';
+          in
+            ''
+              # try to create the partition, if it fails, try to change the type and name
+              if ! sgdisk ${createArgs} ${args}
+              then
+                sgdisk ${args}
+              fi
+              # ensure /dev/disk/by-path/..-partN exists before continuing
+              partprobe "${config.device}" || : # sometimes partprobe fails, but the partitions are still up2date
+              udevadm trigger --subsystem-match=block
+              udevadm settle
+            ''
+        ) sortedPartitions)}
 
         ${
           lib.optionalString (sortedHybridPartitions != [])

--- a/tests/complex.nix
+++ b/tests/complex.nix
@@ -13,7 +13,7 @@ diskoLib.testLib.makeDiskoTest {
   };
   extraTestScript = ''
     machine.succeed("test -b /dev/md/raid1p1");
-
+    machine.succeed("test -b /dev/disk/by-partuuid/f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0")
 
     machine.succeed("mountpoint /zfs_fs");
     machine.succeed("mountpoint /zfs_legacy_fs");


### PR DESCRIPTION
Closes #948. This is my first ever Nix-related PR, so I'd appreciate feedback if you have any!

I wasn't sure if mdadm does expose `partuuid`, I assumed that it did but that may be wrong. I did run the tests, but I wasn't sure if it was wise to include UUIDs in example files. It's probably not a good idea for users to copy the UUID, they should generate their own.