### PR TITLE
zfs: fix the zfs package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737879851,
-        "narHash": "sha256-H+FXIKj//kmFHTTW4DFeOjR7F1z2/3eb2iwN6Me4YZk=",
+        "lastModified": 1738644632,
+        "narHash": "sha256-DyvJjOOGmTSkkEfHq0oWkwtZOgejYIB5S865wmf/qos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d3221fd57cc442a1a522a15eb5f58230f45a304",
+        "rev": "95ea544c84ebed84a31896b0ecea2570e5e0e236",
         "type": "github"
       },
       "original": {

--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -65,6 +65,7 @@ in
   boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
   boot.zfs.forceImportAll = true;
   boot.zfs.forceImportRoot = lib.mkForce true;
+  boot.zfs.package = pkgs.zfs_2_3;
 
   system.build.vmWithDisko = hostPkgs.writers.writeDashBin "disko-vm" ''
     set -efux

--- a/lib/types/zfs.nix
+++ b/lib/types/zfs.nix
@@ -52,7 +52,7 @@
       internal = true;
       readOnly = true;
       type = lib.types.functionTo (lib.types.listOf lib.types.package);
-      default = pkgs: [ pkgs.zfs ];
+      default = pkgs: [ pkgs.zfs_2_3 ];
       description = "Packages";
     };
   };


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/376115 broke all of downstream
that uses zfs. an explicit dependency on a specific version of zfs must
be defined for all uses.

Combined with the flake lock update to make bisect easier.