### PR TITLE
fix: use zfs kernel module which corresponds to user-space tools version in make-disk-image.nix

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -27,7 +27,7 @@ let
         ++ cfg.extraRootModules;
       kernel = pkgs.aggregateModules
         (with cfg.kernelPackages; [ kernel ]
-          ++ lib.optional (lib.elem "zfs" cfg.extraRootModules || configSupportsZfs) zfs);
+          ++ lib.optional (lib.elem "zfs" cfg.extraRootModules || configSupportsZfs) cfg.kernelPackages.${config.boot.zfs.package.kernelModuleAttribute});
     }
   // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu lib)
     {

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -26,7 +26,7 @@ let
         ++ (lib.optional configSupportsZfs "zfs")
         ++ cfg.extraRootModules;
       kernel = pkgs.aggregateModules
-        (with cfg.kernelPackages; [ kernel ]
+        ([ cfg.kernelPackages.kernel ]
           ++ lib.optional (lib.elem "zfs" cfg.extraRootModules || configSupportsZfs) cfg.kernelPackages.${config.boot.zfs.package.kernelModuleAttribute});
     }
   // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu lib)


### PR DESCRIPTION
nixpkgs removed kernelPackages.zfs with following error:
```
error: linuxPackages.zfs has been removed, use zfs_* instead, or linuxPackages.${pkgs.zfs.kernelModuleAttribute}
```

related to #959, but I don't understand the reason to hard-code the version.