### PR TITLE
Addition of granular bcachefs formatting and multi-disk support

### DIFF
--- a/example/bcachefs-multi-disk.nix
+++ b/example/bcachefs-multi-disk.nix
@@ -1,0 +1,93 @@
+{
+  disko.devices = {
+    disk = {
+      bcachefsmain = {
+        device = "/dev/disk/by-path/virtio-pci-0000:00:08.0";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              end = "500M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
+              };
+            };
+            root = {
+              name = "root";
+              end = "-0";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+
+      bcachefsdisk1 = {
+        type = "disk";
+        device = "/dev/disk/by-path/virtio-pci-0000:00:0a.0";
+        content = {
+          type = "gpt";
+          partitions = {
+            bcachefs = {
+              size = "100%";
+              content = {
+                type = "bcachefs_member";
+                pool = "pool1";
+                label = "fast";
+                discard = true;
+                dataAllowed = [ "journal" "btree" ];
+              };
+            };
+          };
+        };
+      };
+      bcachefsdisk2 = {
+        type = "disk";
+        device = "/dev/disk/by-path/virtio-pci-0000:00:0b.0";
+        content = {
+          type = "gpt";
+          partitions = {
+            bcachefs = {
+              size = "100%";
+              content = {
+                type = "bcachefs_member";
+                pool = "pool1";
+                label = "slow";
+                durability = 2;
+                dataAllowed = [ "user" ];
+              };
+            };
+          };
+        };
+      };
+      # use whole disk, ignore partitioning
+      # disk3 = {
+      #   type = "disk";
+      #   device = "/dev/vde";
+      #   content = {
+      #     type = "bcachefs_member";
+      #     pool = "pool1";
+      #     label = "main";
+      #   };
+      # };
+    };
+
+    bcachefs = {
+      pool1 = {
+        type = "bcachefs";
+
+        mountpoint = "/mnt/pool";
+        formatOptions = [ "--compression=zstd" ];
+        mountOptions = [ "verbose" "degraded" ];
+      };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,7 @@
           ./tests/disko-install/configuration.nix
           ./example/hybrid.nix
           ./module.nix
+          # ./example/bcachefs-multi-disk.nix
         ];
       };
       formatter = forAllSystems (

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -46,6 +46,7 @@ let
       inherit (diskoLib.types)
         btrfs
         filesystem
+        bcachefs_member
         zfs
         mdraid
         luks
@@ -71,6 +72,7 @@ let
       inherit (diskoLib.types)
         table
         gpt
+        bcachefs_member
         btrfs
         filesystem
         zfs
@@ -92,6 +94,19 @@ let
         default = null;
         description = "The type of device";
       };
+
+    /**
+      Generate a random UUID using uuidgen
+  
+      mkUUID :: AttrSet -> str
+    **/
+    mkUUID =
+      { pkgs
+      , lib ? pkgs.lib
+      }: 
+      lib.removeSuffix "\n" (builtins.readFile (pkgs.runCommand "gen-uuid" {} ''
+        ${pkgs.util-linux}/bin/uuidgen -r > $out
+      ''));
 
     /**
         like lib.recursiveUpdate but supports merging of lists
@@ -612,6 +627,7 @@ let
         devices = {
           inherit (cfg.config)
             disk
+            bcachefs
             mdadm
             zpool
             lvm_vg
@@ -625,6 +641,11 @@ let
             type = lib.types.attrsOf diskoLib.types.disk;
             default = { };
             description = "Block device";
+          };
+          bcachefs = lib.mkOption {
+            type = lib.types.attrsOf diskoLib.types.bcachefs;
+            default = { };
+            description = "bcachefs device";
           };
           mdadm = lib.mkOption {
             type = lib.types.attrsOf diskoLib.types.mdadm;

--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -130,8 +130,7 @@
             mkdir -p "${config.mountpoint}"
     
             # Capture both the exit code and output of the mount command
-            output=$(bcachefs mount ${lib.optionalString (config.mountOptions != []) "-o ${lib.concatStringsSep "," config.mountOptions}"} UUID="${config.uuid}" "${config.mountpoint}" 2>&1)
-            exit_code=$?
+            output=$(bcachefs mount ${lib.optionalString (config.mountOptions != []) "-o ${lib.concatStringsSep "," config.mountOptions}"} UUID="${config.uuid}" "${config.mountpoint}" 2>&1 || true)
     
             # Check if the error contains "No such device"
             if echo "$output" | grep -iq "no such device"; then
@@ -141,7 +140,7 @@
             else
                 # Propagate the output and exit code if it's not the expected error
                 echo "$output"
-                exit $exit_code
+                exit 1
             fi
         fi
         '';

--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -134,7 +134,7 @@
             exit_code=$?
     
             # Check if the error contains "No such device"
-            if echo "$output" | grep -q "No such device"; then
+            if echo "$output" | grep -iq "no such device"; then
                 echo "Notice: bcachefs mount failed with 'No such device'. This is expected on kernels < 6.13."
                 echo "Current kernel version: $(uname -r)"
                 echo "The mount will succeed when you boot into your final system with a newer kernel."

--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -1,0 +1,224 @@
+# lib/types/bcachefs.nix
+{ config, options, lib, diskoLib, ... }:
+{
+  options = {
+    name = lib.mkOption {
+      type = lib.types.str;
+      default = config._module.args.name;
+      description = "Name of the bcachefs pool";
+    };
+
+    type = lib.mkOption {
+      type = lib.types.enum [ "bcachefs" ];
+      default = "bcachefs";
+      internal = true;
+      description = "Type";
+    };
+
+    formatOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "Additional options for bcachefs format";
+    };
+
+    mountpoint = lib.mkOption {
+      type = lib.types.str;
+      description = "Mount point for the bcachefs pool";
+    };
+
+    mountOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "defaults" ];
+      description = "Options to pass to mount";
+      apply = opts: lib.lists.unique (opts ++ [ "nofail" ]);
+    };
+
+    uuid = lib.mkOption {
+      type = lib.types.strMatching "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}";
+      default = let 
+        # Generate a deterministic but random-looking UUID based on the pool name
+        # This avoids the need for impure access to nixpkgs at evaluation time
+        hash = builtins.hashString "sha256" "${config.name}";
+        hexChars = builtins.substring 0 32 hash;
+        p1 = builtins.substring 0 8 hexChars;
+        p2 = builtins.substring 8 4 hexChars;
+        p3 = builtins.substring 12 4 hexChars;
+        p4 = builtins.substring 16 4 hexChars;
+        p5 = builtins.substring 20 12 hexChars;
+      in
+        "${p1}-${p2}-${p3}-${p4}-${p5}";
+      defaultText = "generated deterministically based on pool name";
+      example = "809b3a2b-828a-4730-95e1-75b6343e415a";
+      description = ''
+        The UUID of the bcachefs filesystem. 
+        If not provided, a deterministic UUID will be generated based on the pool name.
+      '';
+    };
+
+    content = diskoLib.deviceType { parent = config; device = "/dev/bcachefs/${config.name}"; };
+
+    _meta = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = diskoLib.jsonType;
+      default = lib.optionalAttrs (config.content != null) (config.content._meta ["bcachefs" config.name ]);
+      
+      description = "Metadata";
+    };
+
+    _create = diskoLib.mkCreateOption {
+      inherit config options;
+      default = ''
+          echo BCACHEFS POSITION
+          # Read member info from runtime dir - one argument per line
+          readarray -t members < <(cat "$disko_devices_dir/bcachefs-${config.name}-members" || true)
+          readarray -t member_args < <(cat "$disko_devices_dir/bcachefs-${config.name}-args" || true)
+    
+          # Format if needed
+          if bcachefs show-super "''${members[0]}" >/dev/null 2>&1 && ! (bcachefs show-super "''${members[0]}" 2>&1 | grep -qi "Not a bcachefs superblock"); then
+            # Superblock exists and is valid, no reformat needed
+            echo "Found existing bcachefs filesystem, skipping format."
+          else
+            # Need to format - either show-super failed with non-zero exit code
+            # or it returned "Not a bcachefs superblock" message
+            echo "No valid bcachefs filesystem found, formatting..."
+            # bcachefs format --force "''${member_args[@]}" ${toString config.formatOptions}
+              # Add some sleep and sync to ensure all previous operations are complete
+
+            sync
+            sleep 1
+  
+            # Try formatting with additional error handling
+            format_attempts=0
+            max_attempts=3
+            format_success=false
+  
+            while [ $format_attempts -lt $max_attempts ] && [ "$format_success" = "false" ]; do
+              format_attempts=$((format_attempts + 1))
+              echo "Format attempt $format_attempts of $max_attempts..."
+    
+              if bcachefs format --force --uuid=${config.uuid} "''${member_args[@]}" ${toString config.formatOptions}; then
+                format_success=true
+                echo "Format successful"
+              else
+                format_exit=$?
+                echo "Format failed with exit code $format_exit, waiting before retry..."
+                sync
+                sleep 2
+              fi
+            done
+  
+            if [ "$format_success" = "false" ]; then
+              echo "Failed to format bcachefs filesystem after $max_attempts attempts"
+              exit 1
+            fi
+
+            udevadm trigger --subsystem-match=block
+            udevadm settle
+          fi
+
+          ${lib.optionalString (config.content != null) config.content._create}
+      '';
+    };
+
+    _mount = diskoLib.mkMountOption {
+      inherit config options;
+      default = {
+        fs.${config.mountpoint} = ''
+          if ! findmnt "${config.mountpoint}" > /dev/null 2>&1; then
+            ### Hacky work around since bcachefs is broken on earlier kernels
+            mkdir -p "${config.mountpoint}"
+    
+            # Capture both the exit code and output of the mount command
+            output=$(bcachefs mount ${lib.optionalString (config.mountOptions != []) "-o ${lib.concatStringsSep "," config.mountOptions}"} UUID="${config.uuid}" "${config.mountpoint}" 2>&1)
+            exit_code=$?
+    
+            # Check if the error contains "No such device"
+            if echo "$output" | grep -q "No such device"; then
+                echo "Notice: bcachefs mount failed with 'No such device'. This is expected on kernels < 6.13."
+                echo "Current kernel version: $(uname -r)"
+                echo "The mount will succeed when you boot into your final system with a newer kernel."
+            else
+                # Propagate the output and exit code if it's not the expected error
+                echo "$output"
+                exit $exit_code
+            fi
+        fi
+        '';
+      };
+    };
+
+    _unmount = diskoLib.mkUnmountOption {
+      inherit config options;
+      default = {
+        fs.${config.mountpoint} = ''
+          if findmnt "${config.mountpoint}" > /dev/null 2>&1; then
+            umount "${config.mountpoint}"
+          fi
+        '';
+      };
+    };
+    _config = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      default =[
+        {
+          # Basic bcachefs support
+          boot.supportedFilesystems = [ "bcachefs" ];
+          boot.kernelModules = [ "bcachefs" ];
+          # use latest kernel
+          # boot.kernelPackages = config._pkgs.linuxPackages_latest;
+
+          # environment.systemPackages = with lib.pkgs; [
+          #   bcachefs-tools
+          #   util-linux
+          # ];
+
+        }
+        {
+          fileSystems.${config.mountpoint} = {
+            device = "UUID=${config.uuid}";
+            fsType = "bcachefs";
+            options = config.mountOptions;
+          };
+          # Add systemd environment variable for the mount unit
+          systemd.services."mount-${lib.escapeSystemdPath config.mountpoint}".serviceConfig.Environment = "BCACHEFS_BLOCK_SCAN=1";
+          systemd.services."unlock-bcachefs-${lib.escapeSystemdPath config.mountpoint}".serviceConfig.Environment = "BCACHEFS_BLOCK_SCAN=1";
+    
+##############################################################################
+# WORKAROUND: Until the following can be addressed. This means using
+# multi-disk bcachefs as a boot/root partition is not possible in its current
+# form with disko
+# https://github.com/koverstreet/bcachefs-tools/issues/308
+# https://github.com/systemd/systemd/issues/8234#issuecomment-1868238750
+##############################################################################
+          systemd.services."mount-${lib.replaceStrings ["/"] ["-"] config.mountpoint}" = {
+            description = "Mount bcachefs filesystem at ${config.mountpoint}";
+            before = [ "local-fs.target" ];
+            requires = [ "local-fs-pre.target" ];
+            after = [ "local-fs-pre.target" ];
+            environment = {
+              BCACHEFS_BLOCK_SCAN = "1";
+            };
+            script = ''
+              mkdir -p ${config.mountpoint}
+              mount -t bcachefs UUID=${config.uuid} ${config.mountpoint} -o ${lib.concatStringsSep "," config.mountOptions} -o X-mount.mkdir
+            '';
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+            };
+          };
+##############################################################################
+        }
+      ];
+    };
+
+    _pkgs = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo (lib.types.listOf lib.types.package);
+      default = pkgs: [ pkgs.bcachefs-tools ];
+    };
+  };
+}

--- a/lib/types/bcachefs_member.nix
+++ b/lib/types/bcachefs_member.nix
@@ -1,0 +1,113 @@
+# lib/types/bcachefs_member.nix
+{ config, options, lib, diskoLib, parent, device, ... }:
+{
+  options = {
+    type = lib.mkOption {
+      type = lib.types.enum [ "bcachefs_member" ];
+      internal = true;
+      description = "bcachefs member device type";
+    };
+
+    device = lib.mkOption {
+      type = lib.types.str;
+      description = "Device path";
+      default = device;
+    };
+
+    pool = lib.mkOption {
+      type = lib.types.str;
+      description = "Name of the bcachefs pool this device belongs to";
+    };
+
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
+
+    label = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Device label";
+    };
+
+    discard = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable TRIM/discard";
+    };
+
+    dataAllowed = lib.mkOption {
+      type = lib.types.listOf (lib.types.enum [ "journal" "btree" "user" ]);
+      default = [];
+      description = "Allowed data types";
+    };
+
+    durability = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = "Replication factor";
+    };
+
+
+    _meta = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo diskoLib.jsonType;
+      default = dev: {
+        deviceDependencies.bcachefs.${config.pool} = [ dev ];
+      };
+      description = "Metadata";
+    };
+
+    _create = diskoLib.mkCreateOption {
+      inherit config options;
+      default = ''
+        echo BCACHEFS_MEMBER POSITION
+        
+        echo "${lib.escapeShellArg config.device}" >> "$disko_devices_dir/bcachefs-${config.pool}-members"
+    
+        # Write all arguments to the file in a single redirection operation
+        {
+          ${lib.optionalString (config.label != null) ''
+            echo "--label=${lib.escapeShellArg config.label}"
+          ''}
+          ${lib.optionalString config.discard ''
+            echo "--discard"
+          ''}
+          ${lib.optionalString (config.durability != null) ''
+            echo "--durability=${toString config.durability}"
+          ''}
+          ${lib.optionalString (config.dataAllowed != []) ''
+            echo "--data=${lib.escapeShellArg (lib.concatStringsSep "," config.dataAllowed)}"
+          ''}
+          echo "${lib.escapeShellArg config.device}"
+        } >> "$disko_devices_dir/bcachefs-${config.pool}-args"
+      '';
+    };
+
+    _mount = diskoLib.mkMountOption {
+      inherit config options;
+      default = {};
+    };
+
+    _unmount = diskoLib.mkUnmountOption {
+      inherit config options;
+      default = {};
+    };
+
+    _config = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      default = [ ];
+      description = "NixOS configuration";
+    };
+
+    _pkgs = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo (lib.types.listOf lib.types.package);
+      default = pkgs: [ pkgs.bcachefs-tools ];
+      description = "Packages";
+    };
+  };
+}

--- a/tests/bcachefs-multi-disk.nix
+++ b/tests/bcachefs-multi-disk.nix
@@ -1,0 +1,45 @@
+{ pkgs ? import <nixpkgs> { }
+, diskoLib ? pkgs.callPackage ../lib { }
+}:
+diskoLib.testLib.makeDiskoTest {
+  testBoot = true;
+  inherit pkgs;
+  name = "bcachefs-multi";
+  disko-config = ../example/bcachefs-multi-disk.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /mnt/pool");
+    machine.succeed("lsblk >&2");
+  '';
+  #   machine.succeed("mountpoint /mnt/pool")
+    
+  #   # Verify bcachefs mount
+  #   machine.succeed("findmnt -t bcachefs")
+    
+  #   # Check if both devices are part of the pool
+  #   out = machine.succeed("bcachefs fs show")
+  #   if "vdc" not in out or "vdd" not in out:
+  #       raise Exception("Not all devices are part of the bcachefs pool")
+        
+  #   # Verify device labels and roles
+  #   out = machine.succeed("bcachefs device show")
+  #   if "fast" not in out or "slow" not in out:
+  #       raise Exception("Device labels not set correctly")
+    
+  #   # Test basic filesystem operations
+  #   machine.succeed("touch /mnt/pool/test_file")
+  #   machine.succeed("echo 'test content' > /mnt/pool/test_file")
+  #   machine.succeed("test -f /mnt/pool/test_file")
+  #   content = machine.succeed("cat /mnt/pool/test_file").strip()
+  #   if content != "test content":
+  #       raise Exception("File content verification failed")
+  
+  # Required system configuration for bcachefs
+  extraInstallerConfig = {
+    virtualisation.emptyDiskImages = [ 4096 4096 4096 ];
+    boot.supportedFilesystems = [ "bcachefs" ];
+  };
+  
+  extraSystemConfig = {
+    boot.supportedFilesystems = [ "bcachefs" ];
+  };
+}


### PR DESCRIPTION
    These changes provide advanced usage of bcachefs formatting options. Because bcachefs provides
    a one-stop-shop for wiping, partitioning, formatting and mounting with unique features for
    each step, it has been broken out into it's own type if users wish to go beyond a single
    disk setup.

    examples/bcachefs.nix has been updated to showcase this advanced usage and some of the
    available options.

    Because all three processes take place via the type object, requiring "disks" attribute set
    is not longer a hard requirement if a bcachefs type is provided. A check has been added to
    account for that use case.

I will note that I have not gone through the official testing process called out in the contributing guidelines quite yet. I will looking into this soon, just wanted to get this PR out there for visibility :)

I have tested provisioning a VM with a 3 disk pool with this branch using nixos-anywhere, and also running the disko tool manually on another, already provisioned VM.