### PR TITLE
examples/luks: use passwordFile instead of keyFile

### DIFF
--- a/example/complex.nix
+++ b/example/complex.nix
@@ -33,7 +33,7 @@
               content = {
                 type = "luks";
                 name = "crypted1";
-                settings.keyFile = "/tmp/secret.key";
+                settings.passwordFile = "/tmp/secret.key";
                 additionalKeyFiles = [ "/tmp/additionalSecret.key" ];
                 extraFormatArgs = [
                   "--iter-time 1" # insecure but fast for tests

--- a/example/luks-lvm.nix
+++ b/example/luks-lvm.nix
@@ -23,13 +23,13 @@
                 type = "luks";
                 name = "crypted";
                 extraOpenArgs = [ ];
+                # use echo -n "password" > /tmp/secret.key to create the password file
+                passwordFile = "/tmp/secret.key";
+                # use askPassword instead of passwordFile for interactive password prompt
+                # askPassword = true;
                 settings = {
-                  # if you want to use the key for interactive login be sure there is no trailing newline
-                  # for example use `echo -n "password" > /tmp/secret.key`
-                  keyFile = "/tmp/secret.key";
                   allowDiscards = true;
                 };
-                additionalKeyFiles = [ "/tmp/additionalSecret.key" ];
                 content = {
                   type = "lvm_pv";
                   vg = "pool";


### PR DESCRIPTION
keyFile in /tmp will be lsot after reboot, so it is not a good example to copy and paste
