### PR TITLE
fix: device dependencies not sorting correctly redux

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -242,15 +242,23 @@ let
        sortDevicesByDependencies :: AttrSet -> AttrSet -> [ [ str str ] ]
     */
     sortDevicesByDependencies = deviceDependencies: devices:
-      let
-        dependsOn = a: b:
-          lib.elem a (lib.attrByPath b [ ] deviceDependencies);
-        maybeSortedDevices = lib.toposort dependsOn (diskoLib.deviceList devices);
-      in
-      if (lib.hasAttr "cycle" maybeSortedDevices) then
-        abort "detected a cycle in your disk setup: ${maybeSortedDevices.cycle}"
-      else
-        maybeSortedDevices.result;
+    let
+      # First separate disk devices from other devices
+      deviceList = diskoLib.deviceList devices;
+      diskDevices = lib.filter (dev: lib.head dev == "disk") deviceList;
+      nonDiskDevices = lib.filter (dev: lib.head dev != "disk") deviceList;
+    
+      # Regular dependency sorting for non-disk devices
+      dependsOn = a: b:
+        lib.elem a (lib.attrByPath b [ ] deviceDependencies);
+      maybeSortedDevices = lib.toposort dependsOn nonDiskDevices;
+    in
+    if (lib.hasAttr "cycle" maybeSortedDevices) then
+      abort "detected a cycle in your disk setup: ${maybeSortedDevices.cycle}"
+    else
+      # Combine disk devices first, then the sorted non-disk devices
+      diskDevices ++ maybeSortedDevices.result;
+
 
     /* Takes a devices attrSet and returns it as a list
 


### PR DESCRIPTION
Reapplying changes from #968. Still needs review and testing to validate intended functionality. @Lassulus 

Relating to issues discussed int #961 
I think I discovered another bug. I fixed the issue by renaming my type to "dxcachefs" instead of "bcachefs" In the dependency sort list, if there are any types that are alphabetically before the "disk" type, the sortDeviceDependencies function drops those at the top. So my pool object was getting collated as the very first entry in the _create functions. I don't think this was caught because mraid and zpool always appear at the end of the device dependency list due to their position in the alphabet. I think the function will need a specific check to always put disk device types at the beginning of the list.

Feedback on if there is another intended way to track type dependencies.

```nix
sorted = lib.sortDevicesByDependencies nixosConfigurations.testmachine.config.disko.devices._meta.deviceDependencies ({ bcachefs = nixosConfigurations.testmachine.config.disko.devices.bcachefs;  mdadm = nixosConfigurations.testmachine.config.disko.devices.mdadm; zpool = nixosConfigurations.testmachine.config.disko.devices.zpool; disk = nixosConfigurations.testmachine.config.disko.devices.disk; })

nix-repl> :p sorted
[ 
  [ 
    "bcachefs" 
    "pool1"
  ]
  [
    "disk"
    "bcachefsdisk1"
  ]
  [
    "disk"
    "bcachefsdisk2"
  ]
  [
    "disk"
    "bcachefsmain"
  ]
  [
    "disk"
    "cache"
  ]
  [
    "disk"
    "data1"
  ]
  [
    "disk"
    "data2"
  ]
  [
    "disk"
    "data3"
  ]
  [
    "disk"
    "dedup1"
  ]
  [
    "disk"
    "dedup2"
  ]
  [
    "disk"
    "dedup3"
  ]
  [
    "disk"
    "disk1"
  ]
  [
    "disk"
    "disk2"
  ]
  [
    "disk"
    "log1"
  ]
  [
    "disk"
    "log2"
  ]
  [
    "disk"
    "log3"
  ]
  [
    "disk"
    "spare"
  ]
  [
    "disk"
    "special1"
  ]
  [
    "disk"
    "special2"
  ]
  [
    "disk"
    "special3"
  ]
  [
    "mdadm"
    "raid1"
  ]
  [
    "zpool"
    "zroot"
  ]
]
```
VS new behaviour:
```nix
nix-repl> :p sorted
[ 
  [
    "disk"
    "bcachefsdisk1"
  ]
  [
    "disk"
    "bcachefsdisk2"
  ]
  [
    "disk"
    "bcachefsmain"
  ]
  [
    "disk"
    "cache"
  ]
  [
    "disk"
    "data1"
  ]
  [
    "disk"
    "data2"
  ]
  [
    "disk"
    "data3"
  ]
  [
    "disk"
    "dedup1"
  ]
  [
    "disk"
    "dedup2"
  ]
  [
    "disk"
    "dedup3"
  ]
  [
    "disk"
    "disk1"
  ]
  [
    "disk"
    "disk2"
  ]
  [
    "disk"
    "log1"
  ]
  [
    "disk"
    "log2"
  ]
  [
    "disk"
    "log3"
  ]
  [
    "disk"
    "spare"
  ]
  [
    "disk"
    "special1"
  ]
  [
    "disk"
    "special2"
  ]
  [
    "disk"
    "special3"
  ]
  [ 
    "bcachefs" 
    "pool1"
  ]
  [
    "mdadm"
    "raid1"
  ]
  [
    "zpool"
    "zroot"
  ]
]
```