### PR TITLE
fix schellcheck warning failing build

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -865,7 +865,7 @@ let
             default = ''
               umount -Rv "${rootMountPoint}" || :
 
-              # shellcheck disable=SC2043
+              # shellcheck disable=SC2043,2041
               for dev in ${toString (lib.catAttrs "device" (lib.attrValues devices.disk))}; do
                 $BASH ${../disk-deactivate}/disk-deactivate "$dev"
               done
@@ -903,7 +903,7 @@ let
 
                 umount -Rv "${rootMountPoint}" || :
 
-                # shellcheck disable=SC2043
+                # shellcheck disable=SC2043,2041
                 for dev in ${selectedDisks}; do
                   $BASH ${../disk-deactivate}/disk-deactivate "$dev"
                 done


### PR DESCRIPTION
I'm trying to run the command below, and getting an error because of shellcheck warning. 

`nix run github:nix-community/nixos-anywhere -- --flake '.#vm' --vm-test --ssh-port 5555`

```
error: builder for '/nix/store/yy4zrf91sqq29z6crnrqqljwi5977n0y-disko-destroy-format-mount.drv' failed with exit code 1;
       last 7 log lines:
       >
       > In /nix/store/pljg8ral2skimva71gmfp2gh0w5w3sk6-disko-destroy-format-mount line 25:
       > for dev in '/dev/vdb'; do
       >            ^--------^ SC2041 (warning): This is a literal string. To run as a command, use $(..) instead of '..' . 
       >
       > For more information:
       >   https://www.shellcheck.net/wiki/SC2041 -- This is a literal string. To run ...
       For full logs, run 'nix log /nix/store/yy4zrf91sqq29z6crnrqqljwi5977n0y-disko-destroy-format-mount.drv'.
```

This was previously being fixed (https://github.com/nix-community/disko/commit/9c7de5582ed980715a87fdb60c15e3d59cc750dd), but not for all code paths (and I'm now hitting one that's still not fixed)