### PR TITLE
Set `buildPlatform` in make-disk-image

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -74,6 +74,7 @@ let
             disko.devices = lib.mkForce cleanedConfig.disko.devices;
             boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
             nixpkgs.hostPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
+            nixpkgs.buildPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
           }
         ];
       }


### PR DESCRIPTION
Currently if building an image using cross compilation:

```
nixpkgs = {
  config.allowUnsupportedSystem = true;
  hostPlatform = "armv7l-linux";
  buildPlatform = "x86_64-linux";
};
```

And resetting the Disko packages for binFmt use:

```
disko.imageBuilder =
  let
    diskoPkgs = nixpkgs.legacyPackages."x86_64-linux";
  in
  {
    enableBinfmt = true;
    pkgs = diskoPkgs;
    kernelPackages = diskoPkgs.linuxPackages_latest;
  };
```

Something will differ between host/build Platform in diskoPkgs (Not sure what, they look the same when tracing but there is functions that maybe differ) causing it to miss the nixpkgs cache and rebuilding for x86_64-linux. Also resettings buildPlatform fixes this.