### PR TITLE
Fix jq filter syntax error

### DIFF
--- a/disk-deactivate/disk-deactivate.jq
+++ b/disk-deactivate/disk-deactivate.jq
@@ -45,7 +45,7 @@ def deactivate:
     ]
   elif .type == "swap" then
     [
-      "swapoff \(.path)",
+      "swapoff \(.path)"
     ]
   elif .type == "lvm" then
     (.name | split("-")[0]) as $vgname |


### PR DESCRIPTION
The trailing comma causes the following error:

```
+ jq -r --arg disk_to_clear /dev/sda -f /nix/store/4vgl19l2swbfvq2x8d7qrsf8qchrypbj-disk-deactivate/disk-deactivate.jq
jq: error: syntax error, unexpected ']' (Unix shell quoting issues?) at <top-level>, line 49:
    ]
jq: 1 compile error
```