### PR TITLE
Add bcachefs type that supports encryption

### DIFF
--- a/example/bcachefs-encrypted-root.nix
+++ b/example/bcachefs-encrypted-root.nix
@@ -2,14 +2,14 @@
   disko.devices = {
     disk = {
       main = {
-        device = "/dev/disk/by-path/pci-0000:02:00.0-nvme-1";
+        device = "/dev/disk/by-id/some-disk-id";
         type = "disk";
         content = {
           type = "gpt";
           partitions = {
             ESP = {
-              end = "500M";
               type = "EF00";
+              size = "100M";
               content = {
                 type = "filesystem";
                 format = "vfat";
@@ -18,10 +18,10 @@
               };
             };
             root = {
-              name = "root";
-              end = "-0";
+              size = "1G";
               content = {
                 type = "bcachefs";
+                passwordFile = "/tmp/secret.key";
                 mountpoint = "/";
               };
             };

--- a/example/bcachefs.nix
+++ b/example/bcachefs.nix
@@ -21,8 +21,8 @@
               name = "root";
               end = "-0";
               content = {
-                type = "filesystem";
-                format = "bcachefs";
+                type = "bcachefs";
+                passwordFile = "/tmp/secret.key";
                 mountpoint = "/";
               };
             };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -44,6 +44,7 @@ let
     # option for valid contents of partitions (basically like devices, but without tables)
     _partitionTypes = {
       inherit (diskoLib.types)
+        bcachefs
         btrfs
         filesystem
         zfs
@@ -69,6 +70,7 @@ let
     # option for valid contents of devices
     _deviceTypes = {
       inherit (diskoLib.types)
+        bcachefs
         table
         gpt
         btrfs

--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -1,0 +1,98 @@
+{ config, options, diskoLib, lib, rootMountPoint, parent, device, ... }:
+{
+  options = {
+    type = lib.mkOption {
+      type = lib.types.enum [ "bcachefs" ];
+      internal = true;
+      description = "Type";
+    };
+    device = lib.mkOption {
+      type = lib.types.str;
+      default = device;
+      description = "Device to use";
+    };
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments";
+    };
+    passwordFile = lib.mkOption {
+      type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
+      default = null;
+      description = "Path to the file containing the password for encryption";
+      example = "/tmp/disk.key";
+    };
+    mountOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "defaults" ];
+      description = "A list of options to pass to mount.";
+    };
+    mountpoint = lib.mkOption {
+      type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
+      default = null;
+      description = "A path to mount the Bcachefs filesystem to.";
+    };
+    _parent = lib.mkOption {
+      internal = true;
+      default = parent;
+    };
+    _meta = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo diskoLib.jsonType;
+      default = dev: { };
+      description = "Metadata";
+    };
+    _create = diskoLib.mkCreateOption {
+      inherit config options;
+      default = ''
+        # Currently the keyutils package is required due to an upstream bug
+        # https://github.com/NixOS/nixpkgs/issues/32279
+        keyctl link @u @s
+        bcachefs format ${config.device} \
+          ${toString config.extraArgs} \
+          ${lib.optionalString (config.passwordFile != null) "--encrypted <<<\"$(cat ${config.passwordFile})\""}
+        ${lib.optionalString (config.passwordFile != null) "bcachefs unlock ${config.device} <<<\"$(cat ${config.passwordFile})\""}
+      '';
+    };
+    _mount = diskoLib.mkMountOption {
+      inherit config options;
+      default = {
+        fs = lib.optionalAttrs (config.mountpoint != null) {
+          ${config.mountpoint} = ''
+            if ! findmnt ${config.device} "${rootMountPoint}${config.mountpoint}" > /dev/null 2>&1; then
+              ${lib.optionalString (config.passwordFile != null) "bcachefs unlock ${config.device} <<<\"$(cat ${config.passwordFile})\""}
+              mount -t bcachefs ${config.device} "${rootMountPoint}${config.mountpoint}" \
+              ${lib.concatMapStringsSep " " (opt: "-o ${opt}") config.mountOptions} \
+              -o X-mount.mkdir
+            fi
+          '';
+        };
+      };
+    };
+    _config = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      default = [
+        (lib.optional (config.mountpoint != null) {
+          fileSystems.${config.mountpoint} = {
+            device = config.device;
+            fsType = "bcachefs";
+            options = config.mountOptions;
+          };
+        })
+      ];
+      description = "NixOS configuration";
+    };
+    _pkgs = lib.mkOption {
+      internal = true;
+      readOnly = true;
+      type = lib.types.functionTo (lib.types.listOf lib.types.package);
+      default = pkgs:
+        # Currently the keyutils package is required due to an upstream bug
+        # https://github.com/NixOS/nixpkgs/issues/32279
+        with pkgs; [ bcachefs-tools coreutils keyutils ];
+      description = "Packages";
+    };
+  };
+}

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -55,6 +55,7 @@
                   fs-type = lib.mkOption {
                     type = lib.types.nullOr (
                       lib.types.enum [
+                        "bcachefs"
                         "btrfs"
                         "ext2"
                         "ext3"

--- a/tests/bcachefs-encrypted-root.nix
+++ b/tests/bcachefs-encrypted-root.nix
@@ -1,0 +1,20 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "bcachefs-encrypted-root";
+  disko-config = ../example/bcachefs-encrypted-root.nix;
+  enableOCR = true;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+  '';
+  extraInstallerConfig = {
+    boot.supportedFilesystems = [ "bcachefs" ];
+  };
+  bootCommands = ''
+    machine.wait_for_text("enter passphrase for")
+    machine.send_chars("secretsecret\n")
+  '';
+}


### PR DESCRIPTION
This continues work from #242 but uses bcachefs' `-k` option so it uses the keyring session, instead of using the `keyctl` command. It also adds an example and test for an encrypted bcachefs setup and modifies the existing example for the simple, non-encrypted setup to reflect the API change. This PR doesn't aim to support other features of bcachefs such as subvolumes or multi-device setups, which I think deserve their own separate PRs.

This may (partially) address #983, although I haven't tested yet.