### PR TITLE
enable basic macos support

### DIFF
--- a/disk-deactivate/disk-deactivate
+++ b/disk-deactivate/disk-deactivate
@@ -4,5 +4,7 @@ set -efux -o pipefail
 disk=$(realpath "$1")
 
 lsblk -a -f >&2
+# since we currently cannot recursively deactivate swaps on zfs volumes, we need to deactivate all of them.
+lsblk --output-all --json | jq -r -f "$(dirname "$0")/zfs-swap-deactivate.jq" | bash -x
 lsblk --output-all --json | jq -r --arg disk_to_clear "$disk" -f "$(dirname "$0")/disk-deactivate.jq" | bash -x
 lsblk -a -f >&2

--- a/disk-deactivate/zfs-swap-deactivate.jq
+++ b/disk-deactivate/zfs-swap-deactivate.jq
@@ -1,0 +1,10 @@
+def turnOffSwaps:
+    if (.name | test("^zd[0-9]+$")) and .type == "disk" then
+        "swapoff /dev/" + .name
+    else
+        []
+    end
+;
+
+.blockdevices | map(turnOffSwaps) | flatten | join("\n")
+

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
 
           checkJqSyntax = pkgs.runCommand "check-jq-syntax" { nativeBuildInputs = [ pkgs.jq ]; } ''
             echo '{ "blockdevices" : [] }' | jq -r -f ${./disk-deactivate/disk-deactivate.jq} --arg disk_to_clear foo
+            echo '{ "blockdevices" : [] }' | jq -r -f ${./disk-deactivate/zfs-swap-deactivate.jq}
             touch $out
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         "i686-linux"
         "aarch64-linux"
         "riscv64-linux"
+        "aarch64-darwin"
       ];
       forAllSystems = lib.genAttrs supportedSystems;
 

--- a/package.nix
+++ b/package.nix
@@ -8,6 +8,7 @@
   nixos-install-tools,
   binlore,
   diskoVersion,
+  stdenv,
 }:
 
 let
@@ -21,11 +22,19 @@ let
       mkdir -p $out/bin $out/share/disko
       cp -r install-cli.nix cli.nix default.nix disk-deactivate lib $out/share/disko
 
-      for i in disko disko-install; do
-        sed -e "s|libexec_dir=\".*\"|libexec_dir=\"$out/share/disko\"|" "$i" > "$out/bin/$i"
-        chmod 755 "$out/bin/$i"
-        wrapProgram "$out/bin/$i" \
+      wrapProgram "$out/bin/disko" \
+        --set DISKO_VERSION "${diskoVersion}" \
+        --prefix NIX_PATH : "nixpkgs=${path}"
+        --prefix PATH : ${
+          lib.makeBinPath [
+            nix
+            coreutils
+          ]
+        }
+      ${lib.optionalString (!stdenv.isDarwin) ''
+        wrapProgram "$out/bin/disko" \
           --set DISKO_VERSION "${diskoVersion}" \
+          --prefix NIX_PATH : "nixpkgs=${path}" \
           --prefix PATH : ${
             lib.makeBinPath [
               nix
@@ -33,7 +42,11 @@ let
               nixos-install-tools
             ]
           } \
-          --prefix NIX_PATH : "nixpkgs=${path}"
+      ''}
+
+      for i in $out/bin/; do
+        sed -e "s|libexec_dir=\".*\"|libexec_dir=\"$out/share/disko\"|" "$i" > "$out/bin/$i"
+        chmod 755 "$out/bin/$i"
       done
     '';
     # Otherwise resholve thinks that disko and disko-install might be able to execute their arguments
@@ -46,7 +59,7 @@ let
       homepage = "https://github.com/nix-community/disko";
       license = licenses.mit;
       maintainers = with maintainers; [ lassulus ];
-      platforms = platforms.linux;
+      platforms = platforms.unix;
       mainProgram = finalAttrs.name;
     };
   });


### PR DESCRIPTION
We will probably never support native formatting but this is useful when installing NixOS machines and printing formatting script.