### PR TITLE
make-disk-image: add `useVirtualDevices` option

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -55,26 +55,29 @@ let
       customQemu = cfg.qemu;
     }
   );
+
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig config diskoLib.testLib.devices;
-  systemToInstall = extendModules {
+  virtualDevicesModule = {
+    disko.devices = lib.mkForce cleanedConfig.disko.devices;
+    boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
+  };
+  system = extendModules {
     modules = [
       cfg.extraConfig
       {
         disko.testMode = true;
-        disko.devices = lib.mkForce cleanedConfig.disko.devices;
-        boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
       }
     ];
   };
-  systemToInstallNative =
+  cleanedSystem = system.extendModules {
+    modules = [ virtualDevicesModule ];
+  };
+  systemNative =
     if binfmt.systemsAreDifferent then
-      extendModules {
+      system.extendModules {
         modules = [
           cfg.extraConfig
           {
-            disko.testMode = true;
-            disko.devices = lib.mkForce cleanedConfig.disko.devices;
-            boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
             boot.kernelPackages = lib.mkDefault cfg.kernelPackages;
             nixpkgs.hostPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
             nixpkgs.buildPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
@@ -82,7 +85,10 @@ let
         ];
       }
     else
-      systemToInstall;
+      system;
+  cleanedSystemNative = systemNative.extendModules {
+    modules = [ virtualDevicesModule ];
+  };
   dependencies =
     with pkgs;
     [
@@ -111,9 +117,6 @@ let
     install -m600 ${pkgs.OVMF.variables} efivars.fd
   '';
 
-  closureInfo = pkgs.closureInfo {
-    rootPaths = [ systemToInstall.config.system.build.toplevel ];
-  };
   partitioner = ''
     set -efux
     # running udev, stolen from stage-1.sh
@@ -124,7 +127,7 @@ let
     ln -sfn /proc/self/fd/2 /dev/stderr
     mkdir -p /etc/udev
     mount -t efivarfs none /sys/firmware/efi/efivars
-    ln -sfn ${systemToInstallNative.config.environment.etc."udev/rules.d".source} /etc/udev/rules.d
+    ln -sfn ${cleanedSystemNative.config.environment.etc."udev/rules.d".source} /etc/udev/rules.d
     mkdir -p /dev/.mdadm
     ${pkgs.systemdMinimal}/lib/systemd/systemd-udevd --daemon
     partprobe
@@ -134,9 +137,13 @@ let
     ${lib.optionalString diskoCfg.testMode ''
       export IN_DISKO_TEST=1
     ''}
-    ${lib.getExe systemToInstallNative.config.system.build.destroyFormatMount} --yes-wipe-all-disks
+    ${lib.getExe cleanedSystemNative.config.system.build.destroyFormatMount} --yes-wipe-all-disks
   '';
 
+  systemToInstall = if cfg.useVirtualDevices then cleanedSystem else system;
+  closureInfo = pkgs.closureInfo {
+    rootPaths = [ systemToInstall.config.system.build.toplevel ];
+  };
   installer = lib.optionalString cfg.copyNixStore ''
     ${binfmtSetup}
     unset NIX_REMOTE

--- a/module.nix
+++ b/module.nix
@@ -134,6 +134,15 @@ in
         description = "QEMU image format to use for the disk images";
         default = "raw";
       };
+
+      useVirtualDevices = lib.mkOption {
+        type = lib.types.bool;
+        description = ''
+          Replace device names with ones usable in VMs. Ex: `/dev/vda`.
+          Disable this if the disk image is for use on real hardware.
+        '';
+        default = true;
+      };
     };
 
     memSize = lib.mkOption {


### PR DESCRIPTION
I've been using Disko to both configure filesystems on my phone and create the initial images that are flashed. The only problem was that the installed config would have its device names overwritten. This PR adds an option to chose if the virtual/cleaned device names should be installed or not. They're still always used during partitioning.

For those curious, here's an example phone Disko config:
<details>
  <summary><i>expand me</i></summary>
  
```nix
# This config is NOT meant to be used with the Disko CLI. It should only be used with
# the Disko image builder. It represents the boot and root images that will be
# created with Disko image builder and flashed to the phone. NixOS is then able to find
# the partitions using /dev/disk/by-label based on this config.
{
  disko.devices.disk = {
    boot = let
      label = "nixos-boot";
    in {
      type = "disk";
      device = "/dev/disk/by-label/${label}";
      imageName = label;
      # vfat can't be auto-expanded by NixOS, so the initial image size must be
      # the final desired size.
      imageSize = "2G";
      content = {
        type = "filesystem";
        format = "vfat";
        mountpoint = "/boot";
        mountOptions = [
          # See https://github.com/nix-community/disko/issues/527
          "umask=0077"
          # Continuous Discard/trim For SSDs. This partition is small and not written
          # to a ton, so I doubt performance will be an issue.
          "discard"
        ];
        extraArgs = [
          "-n"
          label
          # Sector size.
          "-S"
          "4096"
        ];
      };
    };
    root = let
      label = "nixos-root";
    in {
      type = "disk";
      device = "/dev/disk/by-label/${label}";
      imageName = label;
      imageSize = "5G";
      content = {
        type = "luks";
        name = "crypt";
        settings = {
          # Enable discard/TRIM support. fstrim shouldn't be needed, b/c BTRFS
          # discard=async is default.
          # See https://wiki.archlinux.org/title/Dm-crypt/Specialties#Discard/TRIM_support_for_solid_state_drives_(SSD)
          allowDiscards = true;
          # Improve SSD performance.
          # See https://wiki.archlinux.org/title/Dm-crypt/Specialties#Disable_workqueue_for_increased_solid_state_drive_(SSD)_performance
          bypassWorkqueues = true;
        };
        extraFormatArgs = [
          "--label"
          label
          "--sector-size"
          "4096"
        ];
        # Just for initial encryption in the VM.
        passwordFile = "/tmp/nixos-root.key";
        content = {
          type = "btrfs";
          extraArgs = [
            "--sectorsize"
            "4096"
            "--force" # Force overrite existing partition
          ];
          subvolumes = {
            ...
          };
        };
      };
    };
  };
}
```
</details>