### PR TITLE
udevadm settle: use timeout

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -126,7 +126,7 @@ let
     ${pkgs.systemdMinimal}/lib/systemd/systemd-udevd --daemon
     partprobe
     udevadm trigger --action=add
-    udevadm settle
+    udevadm settle --timeout=120
 
     ${lib.optionalString diskoCfg.testMode ''
       export IN_DISKO_TEST=1

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -204,7 +204,7 @@ in
                             ${lib.optionalString (hp.config.mbrPartitionType != null) ''
                               sfdisk --label-nested dos --part-type "${parent.device}" ${(toString partition.config._index)} ${hp.config.mbrPartitionType}
                               udevadm trigger --subsystem-match=block
-                              udevadm settle
+                              udevadm settle --timeout 120
                             ''}
                             ${lib.optionalString hp.config.mbrBootableFlag ''
                               sfdisk --label-nested dos --activate "${parent.device}" ${(toString partition.config._index)}
@@ -288,7 +288,7 @@ in
             # ensure /dev/disk/by-path/..-partN exists before continuing
             partprobe "${config.device}" || : # sometimes partprobe fails, but the partitions are still up2date
             udevadm trigger --subsystem-match=block
-            udevadm settle
+            udevadm settle --timeout 120
           ''
         ) sortedPartitions}
 

--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -66,7 +66,7 @@
             "''${disk_devices[@]}"
           partprobe "/dev/md/${config.name}"
           udevadm trigger --subsystem-match=block
-          udevadm settle
+          udevadm settle --timeout=120
           # for some reason mdadm devices spawn with an existing partition table, so we need to wipe it
           sgdisk --zap-all "/dev/md/${config.name}"
         fi

--- a/lib/types/table.nix
+++ b/lib/types/table.nix
@@ -147,7 +147,7 @@
                   # ensure /dev/disk/by-path/..-partN exists before continuing
                   partprobe "${config.device}"
                   udevadm trigger --subsystem-match=block
-                  udevadm settle
+                  udevadm settle --timeout 120
                   ${lib.optionalString partition.bootable ''
                     parted -s "${config.device}" -- set ${toString partition._index} boot on
                   ''}
@@ -157,7 +157,7 @@
                   # ensure further operations can detect new partitions
                   partprobe "${config.device}"
                   udevadm trigger --subsystem-match=block
-                  udevadm settle
+                  udevadm settle --timeout 120
                 '') config.partitions
               )}
             fi

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -68,7 +68,7 @@
           zvol_wait
           partprobe "/dev/zvol/${config._parent.name}/${config.name}"
           udevadm trigger --subsystem-match=block
-          udevadm settle
+          udevadm settle --timeout=120
         fi
         ${lib.optionalString (config.content != null) config.content._create}
       '';


### PR DESCRIPTION

there are cases where this can just indefinitly hang as we can see in VM
tests. Let's add a tie breaker.