### PR TITLE
Add destroy option

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -866,9 +866,17 @@ let
               umount -Rv "${rootMountPoint}" || :
 
               # shellcheck disable=SC2043,2041
-              for dev in ${toString (lib.catAttrs "device" (lib.attrValues devices.disk))}; do
+              for dev in ${
+                toString (
+                  lib.catAttrs "device" (
+                    lib.attrValues (lib.filterAttrs (name: disk: (disk.destroy or true)) devices.disk)
+                  )
+                )
+              };
+              do
                 $BASH ${../disk-deactivate}/disk-deactivate "$dev"
               done
+
             '';
           };
           _destroy = lib.mkOption {
@@ -879,7 +887,9 @@ let
             '';
             default =
               let
-                selectedDisks = lib.escapeShellArgs (lib.catAttrs "device" (lib.attrValues devices.disk));
+                selectedDisks = lib.escapeShellArgs (
+                  lib.catAttrs "device" (lib.filterAttrs (name: disk: (disk.destroy or true)) devices.disk)
+                );
               in
               ''
                 if [ "$1" != "--yes-wipe-all-disks" ]; then
@@ -904,7 +914,11 @@ let
                 umount -Rv "${rootMountPoint}" || :
 
                 # shellcheck disable=SC2043,2041
-                for dev in ${selectedDisks}; do
+                for dev in ${
+                  toString (
+                    lib.catAttrs "device" (lib.filterAttrs (name: disk: (disk.destroy or true)) devices.disk)
+                  )
+                }; do
                   $BASH ${../disk-deactivate}/disk-deactivate "$dev"
                 done
               '';

--- a/lib/types/disk.nix
+++ b/lib/types/disk.nix
@@ -22,6 +22,11 @@
       type = diskoLib.optionTypes.absolute-pathname; # TODO check if subpath of /dev ? - No! eg: /.swapfile
       description = "Device path";
     };
+    destroy = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "If false, disko will not wipe or destroy this disk's contents during the destroy stage";
+    };
     imageName = lib.mkOption {
       type = lib.types.str;
       default = config.name;

--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -130,7 +130,7 @@ in
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        if ! blkid "${config.device}" >/dev/null || ! (blkid "${config.device}" -o export | grep -q '^TYPE='); then
+        if ! blkid "${config.device}" >/dev/null || ! (cryptsetup isLuks "${config.device}"); then
           ${lib.optionalString config.askPassword ''
             askPassword() {
               if [ -z ''${IN_DISKO_TEST+x} ]; then
@@ -151,13 +151,15 @@ in
             done
           ''}
           cryptsetup -q luksFormat "${config.device}" ${toString config.extraFormatArgs} ${keyFileArgs}
-          ${cryptsetupOpen} --persistent
-          ${toString (
-            lib.forEach config.additionalKeyFiles (keyFile: ''
-              cryptsetup luksAddKey "${config.device}" ${keyFile} ${keyFileArgs}
-            '')
-          )}
         fi
+
+        ${cryptsetupOpen} --persistent
+        ${toString (
+          lib.forEach config.additionalKeyFiles (keyFile: ''
+            cryptsetup luksAddKey "${config.device}" ${keyFile} ${keyFileArgs}
+          '')
+        )}
+
         ${lib.optionalString (config.content != null) config.content._create}
       '';
     };


### PR DESCRIPTION
1. This introduces a `destroy` option (which defaults to `true`). Setting it to `false` will prevent the corresponding disk from being wiped during the destroy stage.

2. The second commit (72383cd20fc788fe2a288246b1f010b009b2b074) improves the detection and handling of already existing luks devices. The previous check didn't check for a luks device explicitly, and the luks dev was never opened if the check failed.

Let me know if you prefer splitting these in 2 separate PRs.