### PR TITLE
Make bcachefs subvolumes boot-time mount tests pass + add more bcachefs tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ result-*
 
 # Created by the NixOS interactive test driver
 .nixos-test-history
+
+# Created by `:bl` in `nix repl`
+repl-result-out

--- a/example/bcachefs.nix
+++ b/example/bcachefs.nix
@@ -23,7 +23,7 @@
               content = {
                 type = "bcachefs";
                 # This refers to a filesystem in the `bcachefs_filesystems` attrset below.
-                filesystem = "unmounted_subvolumes_in_multi";
+                filesystem = "mounted_subvolumes_in_multi";
                 label = "group_a.vdb2";
                 extraFormatArgs = [
                   "--discard"
@@ -44,7 +44,7 @@
               size = "100%";
               content = {
                 type = "bcachefs";
-                filesystem = "unmounted_subvolumes_in_multi";
+                filesystem = "mounted_subvolumes_in_multi";
                 label = "group_a.vdc1";
                 extraFormatArgs = [
                   "--discard"
@@ -65,7 +65,7 @@
               size = "100%";
               content = {
                 type = "bcachefs";
-                filesystem = "unmounted_subvolumes_in_multi";
+                filesystem = "mounted_subvolumes_in_multi";
                 label = "group_b.vdd1";
                 extraFormatArgs = [
                   "--force"
@@ -82,93 +82,12 @@
         content = {
           type = "gpt";
           partitions = {
-            vde1 = {
-              size = "100%";
-              content = {
-                type = "bcachefs";
-                filesystem = "mounted_subvolumes_in_multi";
-                label = "group_a.vde1";
-                extraFormatArgs = [
-                  "--discard"
-                ];
-              };
-            };
-          };
-        };
-      };
-
-      vdf = {
-        device = "/dev/vdf";
-        type = "disk";
-        content = {
-          type = "gpt";
-          partitions = {
-            vdf1 = {
-              size = "100%";
-              content = {
-                type = "bcachefs";
-                filesystem = "mounted_subvolumes_in_multi";
-                label = "group_a.vdf1";
-                extraFormatArgs = [
-                  "--discard"
-                ];
-              };
-            };
-          };
-        };
-      };
-
-      vdg = {
-        device = "/dev/vdg";
-        type = "disk";
-        content = {
-          type = "gpt";
-          partitions = {
-            vdd1 = {
-              size = "100%";
-              content = {
-                type = "bcachefs";
-                filesystem = "mounted_subvolumes_in_multi";
-                label = "group_b.vdg1";
-                extraFormatArgs = [
-                  "--force"
-                ];
-              };
-            };
-          };
-        };
-      };
-
-      vdh = {
-        device = "/dev/vdh";
-        type = "disk";
-        content = {
-          type = "gpt";
-          partitions = {
-            vdd1 = {
-              size = "100%";
-              content = {
-                type = "bcachefs";
-                filesystem = "no_reliance_on_external_subvolume";
-                label = "group_a.vdh1";
-              };
-            };
-          };
-        };
-      };
-
-      vdi = {
-        device = "/dev/vdi";
-        type = "disk";
-        content = {
-          type = "gpt";
-          partitions = {
             vdd1 = {
               size = "100%";
               content = {
                 type = "bcachefs";
                 filesystem = "relies_on_external_subvolume";
-                label = "group_a.vdi1";
+                label = "group_a.vde1";
               };
             };
           };
@@ -177,10 +96,44 @@
     };
 
     bcachefs_filesystems = {
-      # Example showing unmounted subvolumes in a multi-disk configuration.
-      unmounted_subvolumes_in_multi = {
+      # Example showing mounted subvolumes in a multi-disk configuration.
+      mounted_subvolumes_in_multi = {
         type = "bcachefs_filesystem";
         passwordFile = "/tmp/secret.key";
+        extraFormatArgs = [
+          "--compression=lz4"
+          "--background_compression=lz4"
+        ];
+        subvolumes = {
+          # Subvolume name is different from mountpoint.
+          "subvolumes/root" = {
+            mountpoint = "/";
+            mountOptions = [
+              "verbose"
+            ];
+          };
+          # Subvolume name is the same as the mountpoint.
+          "subvolumes/home" = {
+            mountpoint = "/home";
+          };
+          # Nested subvolume doesn't need a mountpoint as its parent is mounted.
+          "subvolumes/home/user" = {
+          };
+          # Parent is not mounted so the mountpoint must be set.
+          "subvolumes/nix" = {
+            mountpoint = "/nix";
+          };
+          # This subvolume will be created but not mounted.
+          "subvolumes/test" = {
+          };
+        };
+      };
+
+      # Example showing a bcachefs filesystem without subvolumes
+      # and which relies on a subvolume in another filesystem being mounted.
+      relies_on_external_subvolume = {
+        type = "bcachefs_filesystem";
+        mountpoint = "/home/Documents";
         extraFormatArgs = [
           "--compression=lz4"
           "--background_compression=lz4"
@@ -188,61 +141,7 @@
         mountOptions = [
           "verbose"
         ];
-        mountpoint = "/";
-        subvolumes = {
-          "subvolumes/rootfs" = { };
-          "subvolumes/home" = { };
-          "subvolumes/home/user" = { };
-          "subvolumes/nix" = { };
-          "subvolumes/test" = { };
-        };
       };
-
-      # # Example showing mounted subvolumes in a multi-disk configuration (not yet working).
-      # mounted_subvolumes_in_multi = {
-      #   type = "bcachefs_filesystem";
-      #   passwordFile = "/tmp/secret.key";
-      #   extraFormatArgs = [
-      #     "--compression=lz4"
-      #     "--background_compression=lz4"
-      #   ];
-      #   mountOptions = [
-      #     "verbose"
-      #   ];
-      #   subvolumes = {
-      #     # Subvolume name is different from mountpoint
-      #     "foo" = {
-      #       mountpoint = "/bar";
-      #     };
-      #     # Subvolume name is the same as the mountpoint
-      #     "home" = {
-      #       mountpoint = "/home";
-      #     };
-      #     # Sub(sub)volume doesn't need a mountpoint as its parent is mounted
-      #     "home/user" = {
-      #     };
-      #     # Parent is not mounted so the mountpoint must be set
-      #     "nix" = {
-      #       mountpoint = "/nix";
-      #     };
-      #     # This subvolume will be created but not mounted
-      #     "test" = {
-      #     };
-      #   };
-      # };
-
-      # Example showing another bcachefs filesystem.
-      no_reliance_on_external_subvolume = {
-        type = "bcachefs_filesystem";
-        mountpoint = "/sometestdir";
-      };
-
-      # # Example showing another bcachefs filesystem that relies on a subvolume
-      # # in another filesystem being mounted (not yet working).
-      # relies_on_external_subvolume = {
-      #   type = "bcachefs_filesystem";
-      #   mountpoint = "/home/somedir/vdf1";
-      # };
     };
   };
 }

--- a/lib/types/bcachefs_filesystem.nix
+++ b/lib/types/bcachefs_filesystem.nix
@@ -113,10 +113,7 @@
               mountpoint = lib.mkOption {
                 type = lib.types.nullOr diskoLib.optionTypes.absolute-pathname;
                 default = null;
-                description = ''
-                  Path to mount the subvolume to.
-                  DO NOT USE. Currently not working.
-                '';
+                description = "Path to mount the subvolume to.";
                 example = "/";
               };
             };
@@ -126,7 +123,19 @@
       default = { };
       description = "List of subvolumes to define.";
       example = {
-        "subvolumes/home" = { };
+        "subvolumes/root" = {
+          mountpoint = "/";
+          extraFormatArgs = [
+            "--compression=lz4"
+            "--background_compression=lz4"
+          ];
+          mountOptions = [
+            "verbose"
+          ];
+        };
+        "subvolumes/home" = {
+          mountpoint = "/home";
+        };
       };
     };
     _parent = lib.mkOption {
@@ -291,7 +300,6 @@
     _config = lib.mkOption {
       internal = true;
       readOnly = true;
-      # @todo Check that this implementation is correct:
       default =
         (lib.optional (config.mountpoint != null) {
           fileSystems.${config.mountpoint} = {


### PR DESCRIPTION
@Mic92 I manually tested our earlier commit and it seems like boot-time mounting of subvolumes actually was working, contrary to what I previously thought. The issue was that the automated test actually needed to unlock each of the mounted subvolumes individually (I didn't realise the boot process presented unlock prompts for each subvolume to be mounted, so the test was only unlocking the first one), which I've now amended with this new commit.

The OCR for the unlock prompts in the automated test seem to take a while though (and also causes my laptop's fans to spin like crazy), so hopefully it doesn't cause any timeouts in the CI.