### PR TITLE
fix: Use and configure grub for mirrored efi partitions

### DIFF
--- a/example/btrfs-raid-mirrored-boot.nix
+++ b/example/btrfs-raid-mirrored-boot.nix
@@ -1,0 +1,81 @@
+{
+  disko.devices.disk = {
+    one = {
+      type = "disk";
+      device = "/dev/vda";
+
+      content = {
+        type = "gpt";
+
+        partitions = {
+          boot = {
+            size = "1M";
+            type = "EF02";
+          };
+
+          esp = {
+            size = "1G";
+            type = "EF00";
+
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot0";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+
+          root = {
+            size = "100%";
+
+            content = {
+              type = "btrfs";
+            };
+          };
+        };
+      };
+    };
+
+    two = {
+      type = "disk";
+      device = "/dev/vdb";
+
+      content = {
+        type = "gpt";
+
+        partitions = {
+          boot = {
+            size = "1M";
+            type = "EF02";
+          };
+
+          esp = {
+            size = "1G";
+            type = "EF00";
+
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot1";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+
+          root = {
+            size = "100%";
+
+            content = {
+              type = "btrfs";
+              mountpoint = "/";
+              extraArgs = [
+                "-f"
+                "-d raid1"
+                "/dev/disk/by-partlabel/disk-one-root"
+              ];
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1033,13 +1033,37 @@ let
             '';
             default =
               with lib;
-              let
-                configKeys = flatten (
-                  map attrNames (flatten (map (dev: dev._config) (flatten (map attrValues (attrValues devices)))))
-                );
-                collectedConfigs = flatten (map (dev: dev._config) (flatten (map attrValues (attrValues devices))));
-              in
-              genAttrs configKeys (key: mkMerge (catAttrs key collectedConfigs));
+              (
+                let
+                  configKeys = flatten (
+                    map attrNames (flatten (map (dev: dev._config) (flatten (map attrValues (attrValues devices)))))
+                  );
+                  collectedConfigs = flatten (map (dev: dev._config) (flatten (map attrValues (attrValues devices))));
+                in
+                genAttrs configKeys (key: mkMerge (catAttrs key collectedConfigs))
+              )
+              // (
+                let
+                  efi_partitions = builtins.filter (part: part.type == "EF00") (
+                    flatten (
+                      map (disk: map (part: part // { device = disk.device; }) (attrValues disk.content.partitions)) (
+                        flatten (map attrValues (attrValues devices))
+                      )
+                    )
+                  );
+                in
+                (optionalAttrs (builtins.length efi_partitions >= 2) {
+                  # Mirrored boot partitions are not supported on systemd-boot.
+                  boot.loader.grub.enable = mkForce true;
+                  boot.loader.grub.devices = mkForce [ ];
+                  boot.loader.grub.mirroredBoots = mkForce (
+                    map (part: {
+                      devices = [ part.device ];
+                      path = part.content.mountpoint;
+                    }) efi_partitions
+                  );
+                })
+              );
           };
         };
       }

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -61,6 +61,7 @@ let
         disko.testMode = true;
         disko.devices = lib.mkForce cleanedConfig.disko.devices;
         boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
+        boot.loader.grub.mirroredBoots = lib.mkForce cleanedConfig.boot.loader.grub.mirroredBoots;
       }
     ];
   };
@@ -73,6 +74,7 @@ let
             disko.testMode = true;
             disko.devices = lib.mkForce cleanedConfig.disko.devices;
             boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
+            boot.loader.grub.mirroredBoots = lib.mkForce cleanedConfig.boot.loader.grub.mirroredBoots;
             nixpkgs.hostPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
             nixpkgs.buildPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
           }

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -182,7 +182,7 @@ let
                   boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
 
                   # grub will install to these devices, we need to force those or we are offset by 1
-                  # we use mkOveride 70, so that users can override this with mkForce in case they are testing grub mirrored boots
+                  # we use mkOverride 70, so that users can override this with mkForce in case they are testing grub mirrored boots
                   boot.loader.grub.devices = lib.mkOverride 70 testConfigInstall.boot.loader.grub.devices;
 
                   assertions = [

--- a/tests/btrfs-raid-mirrored-boot.nix
+++ b/tests/btrfs-raid-mirrored-boot.nix
@@ -1,0 +1,16 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "btrfs-raid-mirrored-boot";
+  disko-config = ../example/btrfs-raid-mirrored-boot.nix;
+  extraTestScript = ''
+    machine.succeed("mountpoint /");
+  '';
+  extraSystemConfig = {
+    # Mirrored boot partitions are not supported on systemd-boot.
+    boot.loader.systemd-boot.enable = false;
+  };
+}


### PR DESCRIPTION
This works on my machine, but for some odd reason grub-install fails when running the check for the example:
```
       > machine # Installing for i386-pc platform.
       > machine # /nix/store/6934ywwmhnxzrim4f8hwff6c22v0sf6i-grub-2.12/sbin/grub-install: warning: File system `ext2' doesn't support embedding.
       > machine # /nix/store/6934ywwmhnxzrim4f8hwff6c22v0sf6i-grub-2.12/sbin/grub-install: error: embedding is not possible, but this is required for cross-disk install.
       > machine # /nix/store/j07f0cnyhdx46j9n3a40xhjk7z9d5njc-install-grub.pl: installation of GRUB on /dev/vda failed: No such file or directory
       > machine # Failed to install bootloader
```

I'm not sure what's wrong there, as the example I added is almost exactly like my real config (minus LUKS and BTRFS subvolumes) and I also tried my real config as an example which doesn't work either.
In my NixOS configuration I have `boot.loader.grub.efiSupport = true;` set, but that doesn't seem to make a difference here as the error from the example does not go away with it.

@Lassulus @Enzime @iFreilicht @Mic92 @phaer can you help me out with this one?