### PR TITLE
[fix] added missing single quote in script

### DIFF
--- a/cli.nix
+++ b/cli.nix
@@ -108,7 +108,7 @@ let
     else if hasDiskoModuleFlake then
       (builtins.getFlake flake).nixosConfigurations.${flakeAttr}.config.system.build.${diskoAttr}
         or (pkgs.writeShellScriptBin "disko-compat-error" ''
-          echo 'Error: Attribute `nixosConfigurations.${flakeAttr}.config.system.build.${diskoAttr}` >&2
+          echo 'Error: Attribute `nixosConfigurations.${flakeAttr}.config.system.build.${diskoAttr}`' >&2
           echo '       not found in flake `${flake}`!' >&2
           echo '       This is probably caused by the locked version of disko in the flake' >&2
           echo '       being different from the version of disko you executed.' >&2


### PR DESCRIPTION
I've run into some problems with `disko` and should be seeing this error message.
But the message is hidden inside the nix store as it currently only outputs

```
/nix/store/2v3y6n08brldbjsrlhv3dzlj6vsknwv1-disko-compat-error/bin/disko-compat-error: line 8: unexpected EOF while looking for matching `''
error: builder for '/nix/store/q0ki67hbi78sqch9d2k0xg18imbf75gk-disko-compat-error.drv' failed with exit code 2
```