### PR TITLE
bcachefs: fix ENOENT during boot

### DIFF
--- a/example/bcachefs.nix
+++ b/example/bcachefs.nix
@@ -129,8 +129,9 @@
         };
       };
 
-      # Example showing a bcachefs filesystem without subvolumes
-      # and which relies on a subvolume in another filesystem being mounted.
+      # Example showing a bcachefs filesystem without subvolumes,
+      # which relies on a subvolume in another filesystem being mounted
+      # and uses a hard-coded UUID.
       relies_on_external_subvolume = {
         type = "bcachefs_filesystem";
         mountpoint = "/home/Documents";
@@ -141,6 +142,7 @@
         mountOptions = [
           "verbose"
         ];
+        uuid = "64e50034-ebe2-eaf8-1f93-cf56266a8d86";
       };
     };
   };

--- a/lib/types/bcachefs_filesystem.nix
+++ b/lib/types/bcachefs_filesystem.nix
@@ -303,7 +303,7 @@
       default =
         (lib.optional (config.mountpoint != null) {
           fileSystems.${config.mountpoint} = {
-            device = "UUID=${config.uuid}";
+            device = "/dev/disk/by-uuid/${config.uuid}";
             fsType = "bcachefs";
             options = lib.unique ([ "X-mount.mkdir" ] ++ config.mountOptions);
             neededForBoot = true;
@@ -311,7 +311,7 @@
         })
         ++ (map (subvolume: {
           fileSystems.${subvolume.mountpoint} = {
-            device = "UUID=${config.uuid}";
+            device = "/dev/disk/by-uuid/${config.uuid}";
             fsType = "bcachefs";
             options = lib.unique (
               [

--- a/tests/bcachefs.nix
+++ b/tests/bcachefs.nix
@@ -109,7 +109,7 @@ diskoLib.testLib.makeDiskoTest {
             | .. \
             | select(.target? == "/home/Documents") \
             | .source \
-            | contains("/dev/vdd1") \
+            | contains("/dev/disk/by-uuid/64e50034-ebe2-eaf8-1f93-cf56266a8d86") \
         '
     """);
 


### PR DESCRIPTION
Addresses: https://github.com/koverstreet/bcachefs/issues/812
Ran into this issue, adding the full path seems to mitigate for the time being.
@nothingnesses 