### PR TITLE
remove quotes from --label creation for bcachefs

### DIFF
--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -66,7 +66,7 @@
       default = ''
         # Write device arguments to temporary directory for bcachefs_filesystem.
         {
-          printf '%s\n' '--label="${config.label}"';
+          printf '%s\n' '--label=${config.label}';
           ${lib.concatMapStrings (args: ''printf '%s\n' '${args}';'') config.extraFormatArgs}
           printf '%s\n' '${config.device}';
         } >> "$disko_devices_dir/bcachefs-${lib.escapeShellArg config.filesystem}";

--- a/tests/bcachefs.nix
+++ b/tests/bcachefs.nix
@@ -48,10 +48,10 @@ diskoLib.testLib.makeDiskoTest {
     # Verify device membership and labels.
     machine.succeed("bcachefs show-super /dev/vda2 | grep 'Devices:' | grep -q '3'");
     machine.succeed("bcachefs show-super /dev/vdd1 | grep 'Devices:' | grep -q '1'");
-    machine.succeed("bcachefs show-super /dev/vda2 | grep 'Label:' | grep -q 'vdb2'");
-    machine.succeed("bcachefs show-super /dev/vda2 | grep 'Label:' | grep -q 'vdc1'");
-    machine.succeed("bcachefs show-super /dev/vda2 | grep 'Label:' | grep -q 'vdd1'");
-    machine.succeed("bcachefs show-super /dev/vdd1 | grep 'Label:' | grep -q 'vde1'");
+    machine.succeed("bcachefs show-super /dev/vda2 | grep -qE '^[[:space:]]+Label:[[:space:]]+vdb2[[:space:]]\([[:digit:]]+\)'");
+    machine.succeed("bcachefs show-super /dev/vda2 | grep -qE '^[[:space:]]+Label:[[:space:]]+vdc1[[:space:]]\([[:digit:]]+\)'");
+    machine.succeed("bcachefs show-super /dev/vda2 | grep -qE '^[[:space:]]+Label:[[:space:]]+vdd1[[:space:]]\([[:digit:]]+\)'");
+    machine.succeed("bcachefs show-super /dev/vdd1 | grep -qE '^[[:space:]]+Label:[[:space:]]+vde1[[:space:]]\([[:digit:]]+\)'");
     machine.fail("bcachefs show-super /dev/vda2 | grep 'Label:' | grep -q 'non-existent'");
 
     # @todo Verify format arguments.


### PR DESCRIPTION
fixes device groups, for example where the disko config given looks like:

`label = "fast.dev1";`

after formatting, the device has a literal label of "fast.dev1" which breaks bcachefs device groups:

`echo fast > /sys/fs/bcachefs/<id>/options/foreground_target`

gives the error Invalid argument, echo fast.dev1 fails as well

`echo "\"fast\""` fails the same, however `echo "\"fast.dev1\""` succeeds

after this, device labels and groups work as expected and any component of the label can be used for a *_target

## examples

1 device's label was set with the disko config `label = "fast.dev1";`
1 set with `extraFormatArgs = [  "--label=fast.dev2" ];`

output from `bcachefs fs usage /`
`"fast.dev1" (device 3):         sda1              rw`
`fast.dev2 (device 4):           sdf1              rw`


setting devices as a promote target:

```
[root@nixos-installer:~]# echo fast.dev1 > /sys/fs/bcachefs/<id>/options/promote_target 
-bash: echo: write error: Invalid argument

[root@nixos-installer:~]# echo fast.dev2 > /sys/fs/bcachefs/<id>/options/promote_target 

[root@nixos-installer:~]# echo "\"fast.dev1\"" > /sys/fs/bcachefs/<id>/options/promote_target 

[root@nixos-installer:~]# 
```

output from `bcachefs show-super /dev/sdf1 | grep Label:`

```
  Label:                                   dev1" (4)
  Label:                                   dev2 (6)
```

## testing

Tested with `nix build --no-link .#checks.x86_64-linux.bcachefs` with the changed test and everything passed.