### PR TITLE
Allow disabling copying of udev rules

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -121,7 +121,9 @@ let
     ln -sfn /proc/self/fd/2 /dev/stderr
     mkdir -p /etc/udev
     mount -t efivarfs none /sys/firmware/efi/efivars
-    ln -sfn ${systemToInstallNative.config.system.build.etc}/etc/udev/rules.d /etc/udev/rules.d
+    ${lib.optionalString cfg.useUdevRules ''
+      ln -sfn ${systemToInstallNative.config.system.build.etc}/etc/udev/rules.d /etc/udev/rules.d
+    ''}
     mkdir -p /dev/.mdadm
     ${pkgs.systemdMinimal}/lib/systemd/systemd-udevd --daemon
     partprobe

--- a/module.nix
+++ b/module.nix
@@ -121,6 +121,15 @@ in
         description = "QEMU image format to use for the disk images";
         default = "raw";
       };
+
+      useUdevRules = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Copy the udev rules in the VM while building. It can be disabled when unnecessary to speed-up the build,
+          and e.g. when cross-building incompatible packages.
+        '';
+      };
     };
 
     memSize = lib.mkOption {


### PR DESCRIPTION
Currently, the builder builds the whole `system.build.etc`, which is a rather enormous closure in some configurations. Also, it requires the build of all packages declared in `systemPackages` for the build architecture, which is in many cases unneeded, and can fail if the packages are platform-specific.