### PR TITLE
gpt: add partition attributes

### DIFF
--- a/example/gpt-bios-compat.nix
+++ b/example/gpt-bios-compat.nix
@@ -11,6 +11,7 @@
             boot = {
               size = "1M";
               type = "EF02"; # for grub MBR
+              attributes = [ 0 ]; # partition attribute
             };
             root = {
               size = "100%";


### PR DESCRIPTION
Cherry picked from https://github.com/nvmd/disko/commit/9dc58d4d49c9f74623a06e2fc20cdfd8bb3cbe8b

Credit @nvmd

Use cases:

- https://github.com/nvmd/nixos-raspberrypi-demo/blob/2847963e7555fc412c1d0f37bb48c761e78f350d/disko-nvme-zfs.nix#L9L11

- https://github.com/nvmd/nixos-raspberrypi-demo/blob/2847963e7555fc412c1d0f37bb48c761e78f350d/flake.nix#L154L160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-partition GPT attributes can now be configured; users may specify attribute bits to set during disk creation (default: none).
  * GPT BIOS-compatible example updated to show partition attribute usage.

* **Refactor**
  * Partition creation flow updated to consistently apply configured GPT attributes during provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->