### PR TITLE
make-disk-image: pre/post-format-files copies content of source path

### DIFF
--- a/docs/disko-images.md
+++ b/docs/disko-images.md
@@ -71,15 +71,15 @@ In the this example we create a flake containing a nixos configuration for
 
    Options:
    * --pre-format-files <src> <dst>
-     copies the src to the dst on the VM, before disko is run
+     copies the content of path <src> to path <dst> on the VM, before disko is run
      This is useful to provide secrets like LUKS keys, or other files you need for formatting
    * --post-format-files <src> <dst>
-     copies the src to the dst on the finished image
+     copies the content of path <src> to path <dst> on the finished image
      These end up in the images later and is useful if you want to add some extra stateful files
      They will have the same permissions but will be owned by root:root
    * --build-memory <amt>
      specify the amount of memory in MiB that gets allocated to the build VM
-     This can be useful if you want to build images with a more involed NixOS config
+     This can be useful if you want to build images with a more involved NixOS config
      The default is 1024 MiB
    ```
 

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -179,15 +179,15 @@ in
 
     Options:
     * --pre-format-files <src> <dst>
-      copies the src to the dst on the VM, before disko is run
+      copies the content of path <src> to path <dst> on the VM, before disko is run
       This is useful to provide secrets like LUKS keys, or other files you need for formatting
     * --post-format-files <src> <dst>
-      copies the src to the dst on the finished image
+      copies the content of path <src> to path <dst> on the finished image
       These end up in the images later and is useful if you want to add some extra stateful files
       They will have the same permissions but will be owned by root:root
     * --build-memory <amt>
       specify the amount of memory in MiB that gets allocated to the build VM
-      This can be useful if you want to build images with a more involed NixOS config
+      This can be useful if you want to build images with a more involved NixOS config
       The default is disko.memSize which defaults to ${builtins.toString options.disko.memSize.default} MiB
     USAGE
     }
@@ -207,13 +207,13 @@ in
       --pre-format-files)
         src=$2
         dst=$3
-        cp --reflink=auto -r "$src" copy_before_disko/"$(echo "$dst" | base64)"
+        cp --reflink=auto -rv "$src" copy_before_disko/"$(echo "$dst" | base64)"
         shift 2
         ;;
       --post-format-files)
         src=$2
         dst=$3
-        cp --reflink=auto -r "$src" copy_after_disko/"$(echo "$dst" | base64)"
+        cp --reflink=auto -rv "$src" copy_after_disko/"$(echo "$dst" | base64)"
         shift 2
         ;;
       --build-memory)
@@ -243,8 +243,8 @@ in
           for src in /tmp/xchg/copy_before_disko/*; do
             [ -e "$src" ] || continue
             dst=$(basename "$src" | base64 -d)
-            mkdir -p "$(dirname "$dst")"
-            cp -r "$src" "$dst"
+            mkdir -p "$dst"
+            cp -rv "$src"/. "$dst"
           done
           set -f
           ${partitioner}
@@ -252,8 +252,8 @@ in
           for src in /tmp/xchg/copy_after_disko/*; do
             [ -e "$src" ] || continue
             dst=/mnt/$(basename "$src" | base64 -d)
-            mkdir -p "$(dirname "$dst")"
-            cp -r "$src" "$dst"
+            mkdir -p "$dst"
+            cp -rv "$src"/. "$dst"
           done
           ${installer}
         ''}


### PR DESCRIPTION
## Problem

diskoImagesScripts `--pre-format-files` destination does not work when its only one level deep

---

when using `diskoImagesScript` `--pre-format-files` using a destination of one path deep


> nix build .\#checks.x86_64-linux.make-disk-image-luks-interactive-impure (diskoImagesScript)

```console
./result --pre-format-files $PWD/pre /tmp
----------8<-------8<-------------
++ for src in /tmp/xchg/copy_before_disko/*
++ '[' -e /tmp/xchg/copy_before_disko/L3RtcAo= ']'
+++ basename /tmp/xchg/copy_before_disko/L3RtcAo=
+++ base64 -d
++ dst=/tmp
+++ dirname /tmp
++ mkdir -p /
++ cp -rv /tmp/xchg/copy_before_disko/L3RtcAo= /tmp
'/tmp/xchg/copy_before_disko/L3RtcAo=' -> '/tmp/L3RtcAo='
'/tmp/xchg/copy_before_disko/L3RtcAo=/secret.key' -> '/tmp/L3RtcAo=/secret.key'
----------8<-------8<-------------
+ passwordFile=/tmp/secret.key
----------8<-------8<-------------
+ cryptsetup -q luksFormat /dev/disk/by-partlabel/disk-main-luks --key-file /dev/fd/63
cat: /tmp/secret.key: No such file or directory
Nothing to read on input.
+ rm -rf /tmp/tmp.vQKPk8IlAw
[    9.533714] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
----------8<-------8<-------------
```

Two levels deep looks like this

```console
./result --pre-format-files $PWD/pre /tmp/pre
----------8<-------8<-------------
++ for src in /tmp/xchg/copy_before_disko/*
++ '[' -e /tmp/xchg/copy_before_disko/L3RtcC9wcmUK ']'
+++ basename /tmp/xchg/copy_before_disko/L3RtcC9wcmUK
+++ base64 -d
++ dst=/tmp/pre
+++ dirname /tmp/pre
++ mkdir -p /tmp
++ cp -rv /tmp/xchg/copy_before_disko/L3RtcC9wcmUK /tmp/pre
'/tmp/xchg/copy_before_disko/L3RtcC9wcmUK' -> '/tmp/pre'
'/tmp/xchg/copy_before_disko/L3RtcC9wcmUK/secret.key' -> '/tmp/pre/secret.key'
```

## Solution

`cp` content of src, remove `dirname` from mkdir to make the full destination path

```console
./result --pre-format-files $PWD/pre /tmp
----------8<-------8<-------------
++ for src in /tmp/xchg/copy_before_disko/*
++ '[' -e /tmp/xchg/copy_before_disko/L3RtcAo= ']'
+++ basename /tmp/xchg/copy_before_disko/L3RtcAo=
+++ base64 -d
++ dst=/tmp
++ mkdir -p /tmp
++ cp -rv /tmp/xchg/copy_before_disko/L3RtcAo=/. /tmp
'/tmp/xchg/copy_before_disko/L3RtcAo=/./secret.key' -> '/tmp/./secret.key'
----------8<-------8<-------------
installation finished!
++ umount -Rv /mnt
umount: /mnt/boot unmounted
umount: /mnt unmounted
[   68.424421] reboot: Power down
```
