### PR TITLE
Add jq as dependency to diskoScriptNoDeps

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -860,6 +860,7 @@ let
                   })
                     "disko"
                     ''
+                      export PATH=${lib.makeBinPath [ pkgs.jq ]}:$PATH
                       ${cfg.config._disko}
                     '';
               };


### PR DESCRIPTION
NixOS installer by default doesn't include `jq`. Using `nixos-anywhere --no-disko-deps` can fail with `jq` not being found.

I'm not sure this is the right fix, but is the easiest one, and `jq` is small enough to not defeat the purpose of nodeps scripts.