### PR TITLE
make-disk-image: use modules  output of a kernel if present

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -43,7 +43,10 @@ let
         ++ (lib.optional configSupportsZfs "zfs")
         ++ cfg.extraRootModules;
       kernel = pkgs.aggregateModules (
-        [ cfg.kernelPackages.kernel ]
+        [
+          cfg.kernelPackages.kernel
+        ]
+        ++ lib.optional (cfg.kernelPackages.kernel ? modules) cfg.kernelPackages.kernel.modules
         ++ lib.optional (
           lib.elem "zfs" cfg.extraRootModules || configSupportsZfs
         ) cfg.kernelPackages.${config.boot.zfs.package.kernelModuleAttribute}


### PR DESCRIPTION
This is a hotfix that could be reverted if we get:

https://github.com/NixOS/nixpkgs/pull/439178

in.

Fixes https://github.com/nix-community/disko/issues/1114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disk image creation now includes kernel module variants when available, improving compatibility and reducing missing-module failures (including for ZFS-enabled images).
  * Kernel customization behaves more predictably: selected kernel modules are included as expected without extra user intervention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->