### PR TITLE
feat: add flake-parts module

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,0 +1,43 @@
+{ lib, ... }:
+{
+  options.flake.diskoConfigurations = lib.mkOption {
+    type = lib.types.lazyAttrsOf lib.types.raw;
+    default = { };
+    description = "Instantiated Disko configurations. Used by `disko` and `disko-install`.";
+    example = {
+      my-pc = {
+        disko.devices = {
+          disk = {
+            my-disk = {
+              device = "/dev/sda";
+              type = "disk";
+              content = {
+                type = "gpt";
+                partitions = {
+                  ESP = {
+                    type = "EF00";
+                    size = "500M";
+                    content = {
+                      type = "filesystem";
+                      format = "vfat";
+                      mountpoint = "/boot";
+                      mountOptions = [ "umask=0077" ];
+                    };
+                  };
+                  root = {
+                    size = "100%";
+                    content = {
+                      type = "filesystem";
+                      format = "ext4";
+                      mountpoint = "/";
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,9 @@
     {
       nixosModules.default = self.nixosModules.disko; # convention
       nixosModules.disko = ./module.nix;
+      flakeModule = self.flakeModules.default;
+      flakeModules.default = self.flakeModules.disko;
+      flakeModules.disko = ./flake-module.nix;
       lib = diskoLib;
       packages = forAllSystems (
         system:


### PR DESCRIPTION
This adds a flake-parts module that defines a flake output attribute for `diskoConfigurations` so that disko users that use flake-parts can benefit from things like type-checking and merging configurations defined in different flake-parts modules.

I was not sure where to put it in the documentation, so I have not documented it yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a flake option to declare Disko configurations, letting users define disk layouts (partitions, filesystems, mount points) consumable by disko and disko-install.

* **Refactor**
  * Expose the default flake module via a top-level alias and standardize module exports to simplify integration and referencing in downstream flakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->