### PR TITLE
lib: fix `mdadm` warning when using `config.system.build.installTest`

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -248,7 +248,10 @@ let
               (
                 if lib.versionAtLeast (lib.versions.majorMinor lib.version) "23.11" then
                   {
+                    # From https://github.com/NixOS/nixpkgs/blob/7a8665e3a624a01b10d10d10b819cb1a8f34ee6e/nixos/modules/profiles/installation-device.nix#L116-L118
                     boot.swraid.enable = true;
+                    # remove warning about unset mail
+                    boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
                   }
                 else
                   {


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/273308 for more context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Suppresses the recurring mdadm “mail not set” warning during software RAID setup on NixOS 23.11 and newer, reducing noisy warnings without changing RAID behavior.

- Chores
  - Adds a harmless configuration to improve signal-to-noise in boot and test logs on newer systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->