### PR TITLE
fix: forward arguments to `vmWithDisko`

### DIFF
--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -82,6 +82,6 @@ in
       -F qcow2 "$tmp"/${lib.escapeShellArg disk.imageName}.qcow2
     '') disks}
     set +f
-    ${config.system.build.vm}/bin/run-*-vm
+    ${config.system.build.vm}/bin/run-*-vm "$@"
   '';
 }


### PR DESCRIPTION
- `vmWithDisko` does not forward qemu arguments to the script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * VM wrapper script now forwards user-supplied arguments, enabling parameterized VM execution with custom parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->