### PR TITLE
gpt: trigger udev after marking hybrid mbr partitions as bootable

### DIFF
--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -229,6 +229,8 @@ in
                             ''}
                             ${lib.optionalString hp.config.mbrBootableFlag ''
                               sfdisk --label-nested dos --activate "${parent.device}" ${(toString partition.config._index)}
+                              udevadm trigger --subsystem-match=block
+                              udevadm settle --timeout 120
                             ''}
                           '';
                         };


### PR DESCRIPTION
Even though we don't depend on the MBR bootable flag in the following steps, not running udevadm trigger and waiting for settle can cause /dev/disk/by-partlabel entries to be absent when formatting filesystems immediately after modifying the partition table.