### PR TITLE
Use mdadm "auto assemble" to mount

### DIFF
--- a/lib/types/mdadm.nix
+++ b/lib/types/mdadm.nix
@@ -82,8 +82,19 @@
     };
     _mount = diskoLib.mkMountOption {
       inherit config options;
-      default = lib.optionalAttrs (config.content != null) config.content._mount;
-      # TODO we probably need to assemble the mdadm somehow
+      default =
+        let
+          content = lib.optionalAttrs (config.content != null) config.content._mount;
+        in
+        {
+          fs = content.fs or { };
+          dev = ''
+            if ! test -e "/dev/md/${config.name}"; then
+              mdadm --assemble --scan
+            fi
+            ${content.dev or ""}
+          '';
+        };
     };
     _unmount = diskoLib.mkUnmountOption {
       inherit config options;

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -88,8 +88,8 @@
       default = {
         dev = ''
           ${lib.optionalString (config.options.keylocation or "none" != "none") ''
-            if [ "$(zfs get keystatus ${config.name} -H -o value)" == "unavailable" ]; then
-              zfs load-key ${config.name}
+            if [ "$(zfs get keystatus ${config._name} -H -o value)" == "unavailable" ]; then
+              zfs load-key ${config._name}
             fi
           ''}
 
@@ -102,9 +102,11 @@
       inherit config options;
       default = {
         dev = ''
-          ${lib.optionalString (
-            config.options.keylocation or "none" != "none"
-          ) "zfs unload-key ${config.name}"}
+          ${lib.optionalString (config.options.keylocation or "none" != "none") ''
+            if [ "$(zfs get keystatus ${config._name} -H -o value)" == "available" ]; then
+              zfs unload-key ${config._name}
+            fi
+          ''}
 
           ${config.content._unmount.dev or ""}
         '';

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -13,6 +13,12 @@
       default = config._module.args.name;
       description = "Name of the dataset";
     };
+    _name = lib.mkOption {
+      type = lib.types.str;
+      default = "${config._parent.name}/${config.name}";
+      internal = true;
+      description = "Fully quantified name for dataset";
+    };
     type = lib.mkOption {
       type = lib.types.enum [ "zfs_volume" ];
       default = "zfs_volume";
@@ -61,8 +67,8 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       default = ''
-        if ! zfs get type "${config._parent.name}/${config.name}" >/dev/null 2>&1; then
-          zfs create "${config._parent.name}/${config.name}" \
+        if ! zfs get type "${config._name}" >/dev/null 2>&1; then
+          zfs create "${config._name}" \
             ${
               lib.concatStringsSep " " (
                 lib.mapAttrsToList (n: v: "-o ${n}=${lib.escapeShellArg v}") config.options


### PR DESCRIPTION
This PR introduces missing mounting behaviour of "Multiple Device RAID" (md raid) constellations. The chosen approach is to let the management tool (mdadm) scan all connected block devices and mount found md raid constellations.

Part of stacked pull requests to enable unmount testing. This is PR 3 out of 4. Stacks on top of #1148.
Only the last commit applies to this PR.

Previous PR #1148, next PR #1150
See #1140 for ealier discussion.