### PR TITLE
tests: use nixpkgs qemu-common for proper machine type configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
               inherit pkgs;
               makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
               eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
+              qemu-common = import (pkgs.path + "/nixos/lib/qemu-common.nix");
             }
           );
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,11 +3,22 @@
   rootMountPoint ? "/mnt",
   makeTest ? import <nixpkgs/nixos/tests/make-test-python.nix>,
   eval-config ? import <nixpkgs/nixos/lib/eval-config.nix>,
+  qemu-common ? import <nixpkgs/nixos/lib/qemu-common.nix>,
 }:
 let
+  # qemu-common is a function that takes { lib, pkgs } and returns QEMU utilities
+  qemu-common-lib = pkgs: qemu-common { inherit lib pkgs; };
+
   outputs = import ../default.nix { inherit lib diskoLib; };
   diskoLib = {
-    testLib = import ./tests.nix { inherit lib makeTest eval-config; };
+    testLib = import ./tests.nix {
+      inherit
+        lib
+        makeTest
+        eval-config
+        qemu-common-lib
+        ;
+    };
     # like lib.types.oneOf but instead of a list takes an attrset
     # uses the field "type" to find the correct type in the attrset
     subType =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,11 +1,19 @@
 {
   makeTest ? import <nixpkgs/nixos/tests/make-test-python.nix>,
   eval-config ? import <nixpkgs/nixos/lib/eval-config.nix>,
+  qemu-common ? import <nixpkgs/nixos/lib/qemu-common.nix>,
   pkgs ? import <nixpkgs> { },
 }:
 let
   lib = pkgs.lib;
-  diskoLib = import ../lib { inherit lib makeTest eval-config; };
+  diskoLib = import ../lib {
+    inherit
+      lib
+      makeTest
+      eval-config
+      qemu-common
+      ;
+  };
 
   allTestFilenames = builtins.map (lib.removeSuffix ".nix") (
     builtins.filter (x: lib.hasSuffix ".nix" x && x != "default.nix") (


### PR DESCRIPTION
QEMU on aarch64 requires an explicit machine type (e.g., '-machine virt'), unlike x86_64 which has a default. Previously, the test script hardcoded 'qemu-kvm' without machine type arguments, causing aarch64 tests to fail with "No machine specified, and there is no default".

By importing and using nixpkgs' qemu-common.nix library, we reuse the existing platform-specific QEMU configuration logic.