### PR TITLE
make-disk-image: auto-detect bcachefs kernel module like zfs

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -14,6 +14,7 @@ let
   checked = diskoCfg.checkScripts;
 
   configSupportsZfs = config.boot.supportedFilesystems.zfs or false;
+  configSupportsBcachefs = config.boot.supportedFilesystems.bcachefs or false;
   binfmt = diskoLib.binfmt {
     inherit
       diskoLib
@@ -41,6 +42,7 @@ let
           "virtio_rng"
         ]
         ++ (lib.optional configSupportsZfs "zfs")
+        ++ (lib.optional configSupportsBcachefs "bcachefs")
         ++ cfg.extraRootModules;
       kernel = pkgs.aggregateModules (
         [
@@ -50,6 +52,10 @@ let
         ++ lib.optional (
           lib.elem "zfs" cfg.extraRootModules || configSupportsZfs
         ) cfg.kernelPackages.${config.boot.zfs.package.kernelModuleAttribute}
+        ++ lib.optional (
+          (lib.elem "bcachefs" cfg.extraRootModules || configSupportsBcachefs)
+          && pkgs.bcachefs-tools ? kernelModule
+        ) (cfg.kernelPackages.callPackage pkgs.bcachefs-tools.kernelModule { })
       );
     }
     // lib.optionalAttrs (diskoLib.vmToolsSupportsCustomQemu lib) {


### PR DESCRIPTION
Automatically include the bcachefs kernel module when bcachefs is detected in extraRootModules or boot.supportedFilesystems.

This follows the same pattern as ZFS.

Alternative to https://github.com/nix-community/disko/pull/1152

Fixes #1151