### PR TITLE
stop using pkgs.path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,9 +62,9 @@
           nixosTests = lib.optionalAttrs pkgs.stdenv.hostPlatform.isx86_64 (
             import ./tests {
               inherit pkgs;
-              makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
-              eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
-              qemu-common = import (pkgs.path + "/nixos/lib/qemu-common.nix");
+              makeTest = import (nixpkgs + "/nixos/tests/make-test-python.nix");
+              eval-config = import (nixpkgs + "/nixos/lib/eval-config.nix");
+              qemu-common = import (nixpkgs + "/nixos/lib/qemu-common.nix");
             }
           );
 

--- a/module.nix
+++ b/module.nix
@@ -4,6 +4,7 @@
   pkgs,
   extendModules,
   diskoLib,
+  modulesPath,
   ...
 }:
 let
@@ -245,8 +246,9 @@ in
     _module.args.diskoLib = import ./lib {
       inherit lib;
       rootMountPoint = config.disko.rootMountPoint;
-      makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
-      eval-config = import (pkgs.path + "/nixos/lib/eval-config.nix");
+      makeTest = import "${modulesPath}/../tests/make-test-python.nix";
+      eval-config = import "${modulesPath}/../lib/eval-config.nix";
+      qemu-common = import "${modulesPath}/../lib/qemu-common.nix";
     };
 
     system.build =


### PR DESCRIPTION
pkgs.path is an expensive copy operation that slow down evaluation by a lot.