### PR TITLE
Correct npins import example

### DIFF
--- a/docs/HowTo.md
+++ b/docs/HowTo.md
@@ -72,10 +72,9 @@ Then add the following to your configuration.nix in the `imports` list:
 ```nix
 let
   sources = import ./npins;
-  disko = import sources.disko {};
 in
 {
-  imports = [ "${disko}/module.nix" ];
+  imports = [ (sources.disko + "/module.nix") ];
   …
 }
 ```


### PR DESCRIPTION
I was stuck on this for a bit until I saw the [npins README](https://github.com/andir/npins/blob/f4e3698681704e74196fa0f905c7dfdd43cf5c86/README.md.in#L262) using the source without calling it as a function.

With the old example, I got this error:
```
        … while evaluating a path segment
         at /core/mini/configuration.nix:12:6:
           11|   imports = [
           12|     "${disko}/module.nix"
             |      ^
           13|     ./disks.nix

       error: cannot coerce a set to a string: { _cliDestroy = «thunk»; _cliDestroyFormatMount = «thunk»; _cliDestroyFormatMountNoDeps = «thunk»; _cliDestroyNoDeps = «thunk»; _cliFormat = «thunk»; _cliFormatMount = «thunk»; _cliFormatMountNoDeps = «thunk»; _cliFormatNoDeps = «thunk»; _cliMount = «thunk»; _cliMountNoDeps = «thunk»; «18 attributes elided» }
```

With the correction,  `system` builds as expected.