### PR TITLE
flake: export lib with references to nixpkgs input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,9 @@
 
       diskoLib = import ./lib {
         inherit (nixpkgs) lib;
+        makeTest = import (nixpkgs + "/nixos/tests/make-test-python.nix");
+        eval-config = import (nixpkgs + "/nixos/lib/eval-config.nix");
+        qemu-common = import (nixpkgs + "/nixos/lib/qemu-common.nix");
       };
     in
     {


### PR DESCRIPTION
This previously pointed at `<nixpkgs/...>`, which might be anything. It caused this error for me, when I tried to use `lib.makeDiskoTest` downstream:

```
error: cannot look up '<nixpkgs/nixos/tests/make-test-python.nix>' in
pure evaluation mode (use '--impure' to override)
```