### PR TITLE
fix: use system.modulesTree for disk image VM kernel modules

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -45,8 +45,8 @@ let
       kernel = pkgs.aggregateModules (
         [
           cfg.kernelPackages.kernel
+          config.system.modulesTree
         ]
-        ++ lib.optional (cfg.kernelPackages.kernel ? modules) cfg.kernelPackages.kernel.modules
         ++ lib.optional (
           lib.elem "zfs" cfg.extraRootModules || configSupportsZfs
         ) cfg.kernelPackages.${config.boot.zfs.package.kernelModuleAttribute}


### PR DESCRIPTION
## Problem

Building disk images with `vmWithDisko` fails on NixOS 25.11 with:
```
kernel-modules-shrunk> Required modules: 9p 9pnet_virtio virtiofs virtio_pci virtio_blk virtio_balloon virtio_rng
kernel-modules-shrunk> Can not derive a closure of kernel modules because no modules were provided.
```

## Cause

The `vmTools.override` in `lib/make-disk-images.nix` was using:
```nix
kernel = pkgs.aggregateModules (
  [
    cfg.kernelPackages.kernel
  ]
  ++ lib.optional (cfg.kernelPackages.kernel ? modules) cfg.kernelPackages.kernel.modules
  ...
);
```
The issue: `cfg.kernelPackages.kernel.modules` points back to the kernel package itself (which contains only `bzImage` and `System.map`), not to the actual kernel modules package.

Further testing gave me this output:

```bash
$ nix eval '.#nixosConfigurations.test.config.boot.kernelPackages.kernel.modules.name'
"linux-6.12.59" 
$ find $(nix eval --raw '...kernel.modules.outPath') -name "*.ko*" | wc -l
0 

$ nix eval '.#nixosConfigurations.test.config.system.modulesTree.name'
"linux-6.12.59-modules" 
$ find $(nix eval --raw '...system.modulesTree.outPath') -name "*.ko*" | wc -l
7035 
```

To verify that the issue is due to version 25.11, I checked the 25.05 and 25.11 output to confirm that the `kernel.modules` attribute suddenly points to something.

```bash
# Test 25.05
nix eval --impure --expr 'let pkgs = (builtins.getFlake "github:nixos/nixpkgs/nixos-25.05").legacyPackages.x86_64-linux; in pkgs.linuxPackages.kernel.modules.name or "none"'

"none"

# Test 25.11
nix eval --impure --expr 'let pkgs = (builtins.getFlake "github:nixos/nixpkgs/nixos-25.11").legacyPackages.x86_64-linux; in pkgs.linuxPackages.kernel.modules.name or "none"'

"linux-6.12.59"
```

## Solution

Use `config.system.modulesTree` instead, which correctly points to the `linux-X.X.X-modules` package containing the actual `.ko` kernel module files needed for the VM initrd.

## Testing

-  All `x86_64-linux` checks pass
- `vmWithDisko` now successfully builds and boots

## Minimal Reproduction

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
    disko.url = "github:nix-community/disko/latest";
  };
  
  outputs = { nixpkgs, disko, ... }: {
    nixosConfigurations.test = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        disko.nixosModules.disko
        ({ modulesPath, ... }: {
          imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
          
          disko.devices.disk.main = {
            device = "/dev/vda";
            type = "disk";
            content = {
              type = "gpt";
              partitions = {
                esp = {
                  size = "512M";
                  type = "EF00";
                  content = {
                    type = "filesystem";
                    format = "vfat";
                    mountpoint = "/boot";
                  };
                };
                root = {
                  size = "100%";
                  content = {
                    type = "filesystem";
                    format = "ext4";
                    mountpoint = "/";
                  };
                };
              };
            };
          };
          
          boot.loader.systemd-boot.enable = true;
          system.stateVersion = "25.11";
        })
      ];
    };
  };
}
```
<details>
<summary>flake.lock</summary>
{
  "nodes": {
    "disko": {
      "inputs": {
        "nixpkgs": "nixpkgs"
      },
      "locked": {
        "lastModified": 1746728054,
        "narHash": "sha256-eDoSOhxGEm2PykZFa/x9QG5eTH0MJdiJ9aR00VAofXE=",
        "owner": "nix-community",
        "repo": "disko",
        "rev": "ff442f5d1425feb86344c028298548024f21256d",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "ref": "latest",
        "repo": "disko",
        "type": "github"
      }
    },
    "nixpkgs": {
      "locked": {
        "lastModified": 1746576598,
        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "ref": "nixpkgs-unstable",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "nixpkgs_2": {
      "locked": {
        "lastModified": 1764522689,
        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
        "owner": "nixos",
        "repo": "nixpkgs",
        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
        "type": "github"
      },
      "original": {
        "owner": "nixos",
        "ref": "nixos-25.11",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "disko": "disko",
        "nixpkgs": "nixpkgs_2"
      }
    }
  },
  "root": "root",
  "version": 7
}
</details>

```bash
nix run '.#nixosConfigurations.test.config.system.build.vmWithDisko'
# Fails with "no modules were provided"
```