### PR TITLE
Propagate bcachefs_filesystem mountOptions to subvolumes

### DIFF
--- a/lib/types/bcachefs_filesystem.nix
+++ b/lib/types/bcachefs_filesystem.nix
@@ -35,6 +35,9 @@
       description = ''
         Options to pass to mount.
         The "X-mount.mkdir" option is always automatically added.
+
+        These options will also be applied to subvolumes of this filesystem,
+        if the filesystem itself isn't mounted directly.
       '';
       example = [
         "noatime"
@@ -319,6 +322,7 @@
                 "X-mount.subdir=${lib.removePrefix "/" subvolume.name}"
               ]
               ++ subvolume.mountOptions
+              ++ lib.optionals (config.mountpoint == null) config.mountOptions
             );
             neededForBoot = true;
           };


### PR DESCRIPTION
Make subvolume mountOptions also include options for the whole
filesystem, but only when the filesystems mountpoint is not specified

My reasoning behind this is that if user specifies mountOptions for the filesystem, but doesn't mount it, it's likely they want those options to apply to subvolumes of that filesystem.
