### PR TITLE
downgrade the priority of kernelPackages set from imageBuilder

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -76,7 +76,7 @@ let
             disko.testMode = true;
             disko.devices = lib.mkForce cleanedConfig.disko.devices;
             boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
-            boot.kernelPackages = cfg.kernelPackages;
+            boot.kernelPackages = lib.mkDefault cfg.kernelPackages;
             nixpkgs.hostPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
             nixpkgs.buildPlatform = lib.mkForce pkgs.stdenv.hostPlatform;
           }


### PR DESCRIPTION
This is needed if user need to custom both
disko.imageBuilder.kernelPackages and boot.kernelPackages
when disko.imageBuilder.enableBinfmt is true.

otherwise, they have conflict priority setting boot.kernelPackages.