### PR TITLE
Fix vm test not respecting `disko.tests.extraConfig` disko overwrites

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -56,12 +56,17 @@ let
     }
   );
   cleanedConfig = diskoLib.testLib.prepareDiskoConfig config diskoLib.testLib.devices;
+  # Merge any disko.devices settings from extraConfig into the cleaned config
+  # This allows tests.extraConfig to override disko settings like settings.keyFile
+  mergedDiskoDevices = lib.recursiveUpdate cleanedConfig.disko.devices (
+    cfg.extraConfig.disko.devices or { }
+  );
   systemToInstall = extendModules {
     modules = [
       cfg.extraConfig
       {
         disko.testMode = true;
-        disko.devices = lib.mkForce cleanedConfig.disko.devices;
+        disko.devices = lib.mkForce mergedDiskoDevices;
         boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
       }
     ];
@@ -73,7 +78,7 @@ let
           cfg.extraConfig
           {
             disko.testMode = true;
-            disko.devices = lib.mkForce cleanedConfig.disko.devices;
+            disko.devices = lib.mkForce mergedDiskoDevices;
             boot.loader.grub.devices = lib.mkForce cleanedConfig.boot.loader.grub.devices;
             boot.kernelPackages = lib.mkDefault cfg.kernelPackages;
             nixpkgs.hostPlatform = lib.mkForce pkgs.stdenv.hostPlatform;

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -165,7 +165,11 @@ let
                           (modulesPath + "/testing/test-instrumentation.nix") # we need these 2 modules always to be able to run the tests
                           (modulesPath + "/profiles/qemu-guest.nix")
                         ];
-                        disko.devices = lib.mkForce testConfigBooted.disko.devices;
+                        # Merge extraSystemConfig's disko.devices settings into testConfigBooted
+                        # This allows tests.extraConfig to override disko settings like settings.keyFile
+                        disko.devices = lib.mkForce (
+                          lib.recursiveUpdate testConfigBooted.disko.devices (extraSystemConfig.disko.devices or { })
+                        );
                       }
                     )
                   ];


### PR DESCRIPTION
@Lassulus This should fix cases where users overwrite some disko configurations inside of  `disko.tests.extraConfig`. The docs on this setting state:

> Extra NixOS config for your test. Can be used to specify a different luks key for tests.
> A dummy key is in /tmp/secret.key

Consider the following setting: You have `boot.initrd.systemd.enable = true;` (systemd in Stage 1) and you have a disko config with luks like this:

```nix
type = "luks";
name = "main";
extraOpenArgs = [ "--allow-discards" ];
passwordFile = lib.mkDefault "/tmp/secret.key";
askPassword = false;
settings = {
  allowDiscards = true;
};
```
So usually you provide a passwordFile and when booting you just type that password. 

However, for VM tests you want to unlock this luks partition non-interactively. So you:

- Create a systemd service that provides `/tmp/secret.key` during boot
- Set `settings.keyFile = "/tmp/secret.key` so that cryptsetup uses the keyFile to unlock the partition

So I expected this to work:

```nix
disko.tests.extraConfig = {
  disko.devices.disk.main.content.partitions.main.content.settings.keyFile = "/tmp/secret.key";
};
```

While nix repl does show:

```nix
❯ nix repl .
Nix 2.31.2+1
Type :? for help.
warning: Git tree '/home/jonathan/git/DSEE/NIXOS/disko-reprex' is dirty
Loading installable 'git+file:///home/jonathan/git/DSEE/NIXOS/disko-reprex#'...
Added 1 variables.
nixosConfigurations
nix-repl> nixosConfigurations.test.config.virtualisation.vmVariantWithDisko.boot.initrd.luks.devices.main.keyFile
"/tmp/secret.key"
```
Running
```
❯ nix run github:nix-community/nixos-anywhere -- \
  --flake .#test \
  --vm-test
```
Will stop at the interactive password prompt.

With this PR, it will respect the keyFile setting correctly and auto-unlock.

See #1185 for a reproducible example.