### PR TITLE
fix(bcachefs): use colon-separated device list for mount

### DIFF
--- a/lib/types/bcachefs.nix
+++ b/lib/types/bcachefs.nix
@@ -64,6 +64,8 @@
       # The current file should not run the `bcachefs format` command. Instead, the`bcachefs format` command will be ran
       # in the `_create` attribute in bcachefs_filesystem.nix, once it has collected and generated the arguments specifying the devices that should be part of the filesystem.
       default = ''
+        # Write devices to temporary directory for bcachefs_filesystem.
+        printf '%s\n' '${config.device}' >> "$disko_devices_dir/bcachefs-${lib.escapeShellArg config.filesystem}-devices";
         # Write device arguments to temporary directory for bcachefs_filesystem.
         {
           printf '%s\n' '--label=${config.label}';

--- a/lib/types/bcachefs_filesystem.nix
+++ b/lib/types/bcachefs_filesystem.nix
@@ -9,9 +9,7 @@
 }:
 let
   # colon separated list of devices, as UUID expansion is unreliable
-  colonSeparatedDevices = ''
-    $(awk '{print $NF}' "$disko_devices_dir/bcachefs-${config.name}" | paste -sd ":" -)
-  '';
+  colonSeparatedDevices = ''$(paste -sd ":" "$disko_devices_dir/bcachefs-${config.name}-devices")'';
 in
 {
   options = {


### PR DESCRIPTION
The uuid expansion of the mount command is known to be unreliable (can confirm, as it doesn't work for me), so this patch uses the explicit colon-separated device list syntax instead.
It does _not_ use it for unlock or fstab entries, as they don't seem to support it and, at least for me, work without it.
This patch worked to install my multi-disk bcachefs setup.