### PR TITLE
example: add comments as warning about legacy table type

### DIFF
--- a/example/legacy-table-with-whitespace.nix
+++ b/example/legacy-table-with-whitespace.nix
@@ -1,3 +1,8 @@
+# This example with the legacy table should not be used. We recommend using the
+# gpt type instead. More information about this warning may be found in the
+# documentation.
+#
+# https://github.com/nix-community/disko/blob/master/docs/table-to-gpt.md
 {
   disko.devices = {
     disk = {

--- a/example/legacy-table.nix
+++ b/example/legacy-table.nix
@@ -1,3 +1,8 @@
+# This example with the legacy table should not be used. We recommend using the
+# gpt type instead. More information about this warning may be found in the
+# documentation.
+#
+# https://github.com/nix-community/disko/blob/master/docs/table-to-gpt.md
 {
   disko.devices = {
     disk = {

--- a/example/stand-alone/configuration.nix
+++ b/example/stand-alone/configuration.nix
@@ -1,3 +1,8 @@
+# This example with the legacy table should not be used. We recommend using the
+# gpt type instead. More information about this warning may be found in the
+# documentation.
+#
+# https://github.com/nix-community/disko/blob/master/docs/table-to-gpt.md
 {
   pkgs,
   lib,


### PR DESCRIPTION
Just did the mistake to copy and paste one legacy table type example. Ran into the warning and was a bit sad.

Adding these comments while referring to the documentation could help some undercaffeinated disko users like me.