### PR TITLE
Add cross-compilation support for disk formatting (ZFS)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,13 @@ in
     cfg: pkgs: ((eval cfg).config.disko.devices._scripts { inherit pkgs checked; }).destroyNoDeps;
 
   _cliFormat = cfg: pkgs: ((eval cfg).config.disko.devices._scripts { inherit pkgs checked; }).format;
+  # for cross-compilation: hostPkgs for format, targetPkgs for mount scripts
+  _cliFormatCross =
+    cfg: hostPkgs: targetPkgs:
+    ((eval cfg).config.disko.devices._scripts {
+      pkgs = targetPkgs;
+      inherit hostPkgs checked;
+    }).format;
   _cliFormatNoDeps =
     cfg: pkgs: ((eval cfg).config.disko.devices._scripts { inherit pkgs checked; }).formatNoDeps;
 

--- a/disko-install
+++ b/disko-install
@@ -179,6 +179,45 @@ maybeRun () {
   fi
 }
 
+checkBinfmtForCrossCompilation() {
+  local flake=$1
+  local flakeAttr=$2
+
+  # Get the current system (host) from Nix
+  local host_system
+  host_system=$(nix-instantiate --eval --expr 'builtins.currentSystem' 2>/dev/null | tr -d '"') || return 0
+
+  # Get the target system by evaluating the flake (without building)
+  local target_system
+  target_system=$(nix eval --raw "${flake}#nixosConfigurations.${flakeAttr}.pkgs.system" 2>/dev/null) || return 0
+
+  # If systems match, no cross-compilation, no binfmt needed
+  if [[ "$host_system" == "$target_system" ]]; then
+    return 0
+  fi
+
+  # Cross-compilation detected, check binfmt configuration
+  local binfmt_file="/proc/sys/fs/binfmt_misc/$target_system"
+  if [[ ! -f "$binfmt_file" ]]; then
+    echo "Cross-compiling from $host_system to $target_system requires binfmt_misc configuration." >&2
+    echo "Add this to your NixOS configuration:" >&2
+    echo "  boot.binfmt.emulatedSystems = [ \"$target_system\" ];" >&2
+    echo "Then rebuild: nixos-rebuild switch" >&2
+    exit 1
+  fi
+
+  # Check for F flag (required for chroot)
+  local flags
+  flags=$(grep "^flags:" "$binfmt_file" | cut -d: -f2 | tr -d ' ')
+  if [[ ! "$flags" =~ F ]]; then
+    echo "Cross-compilation requires the binfmt_misc 'F' flag (current: $flags)" >&2
+    echo "Add this to your NixOS configuration:" >&2
+    echo "  boot.binfmt.preferStaticEmulators = true;" >&2
+    echo "Then rebuild: nixos-rebuild switch" >&2
+    exit 1
+  fi
+}
+
 main() {
   parseArgs "$@"
 
@@ -231,6 +270,9 @@ main() {
   if [[ -z ${dry_run-} ]]; then
      trap cleanupMountPoint EXIT
   fi
+
+  # Check binfmt configuration for cross-compilation before building
+  checkBinfmtForCrossCompilation "$flake" "$flakeAttr"
 
   if ! outputs=$(nixBuild "${libexec_dir}"/install-cli.nix \
     "${nix_args[@]}" \

--- a/example/cross-zfs.nix
+++ b/example/cross-zfs.nix
@@ -1,0 +1,59 @@
+# Example ZFS configuration used to test cross-architecture disk formatting.
+# When formatting disks for a different architecture (e.g., preparing an
+# aarch64 disk from an x86_64 host), disko automatically uses host-native
+# tools for ZFS operations that require kernel communication.
+{
+  disko.devices = {
+    disk = {
+      main = {
+        type = "disk";
+        device = "/dev/disk/by-id/some-disk-id";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zroot";
+              };
+            };
+          };
+        };
+      };
+    };
+    zpool = {
+      zroot = {
+        type = "zpool";
+        options.cachefile = "none";
+        rootFsOptions = {
+          compression = "lz4";
+          "com.sun:auto-snapshot" = "false";
+        };
+        mountpoint = "/";
+
+        datasets = {
+          home = {
+            type = "zfs_fs";
+            mountpoint = "/home";
+          };
+          nix = {
+            type = "zfs_fs";
+            mountpoint = "/nix";
+            options.atime = "off";
+          };
+        };
+      };
+    };
+  };
+}

--- a/install-cli.nix
+++ b/install-cli.nix
@@ -5,10 +5,14 @@
   extraSystemConfig ? "{}",
   writeEfiBootEntries ? false,
   rootMountPoint ? "/mnt",
+  hostSystem ? builtins.currentSystem, # the system running the format script, for cross-compilation
 }:
 let
   originalSystem = (builtins.getFlake "${flake}").nixosConfigurations."${flakeAttr}";
   lib = originalSystem.pkgs.lib;
+
+  # Get host pkgs for cross-compilation (format scripts need host-native tools)
+  hostPkgs = import originalSystem.pkgs.path { system = hostSystem; };
 
   deviceName =
     name:
@@ -57,11 +61,19 @@ let
       )
     ];
   };
+  # Build scripts with hostPkgs for format/destroy, targetPkgs for mount
+  # This enables cross-compilation: format scripts use host-native tools
+  # that can communicate with the running kernel
+  scripts = diskoSystem.config.disko.devices._scripts {
+    pkgs = diskoSystem.pkgs; # target pkgs for mount scripts
+    inherit hostPkgs; # host pkgs for format/destroy scripts
+  };
 in
 {
   installToplevel = installSystem.config.system.build.toplevel;
   closureInfo = installSystem.pkgs.closureInfo {
     rootPaths = [ installSystem.config.system.build.toplevel ];
   };
-  inherit (diskoSystem.config.system.build) formatScript mountScript diskoScript;
+  # Use scripts built with hostPkgs for cross-compilation support
+  inherit (scripts) formatScript mountScript diskoScript;
 }

--- a/tests/cross-zfs-aarch64.nix
+++ b/tests/cross-zfs-aarch64.nix
@@ -1,0 +1,42 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+let
+  lib = pkgs.lib;
+  targetSystem = "aarch64-linux";
+  crossAttr = "aarch64-multiplatform";
+
+  diskoConfig = import ../example/cross-zfs.nix;
+  testConfig = diskoLib.testLib.prepareDiskoConfig diskoConfig (lib.tail diskoLib.testLib.devices);
+
+  tsp-generator = pkgs.callPackage ../. { checked = false; };
+  crossPkgs = pkgs.pkgsCross.${crossAttr};
+  hostFormatScript = (tsp-generator._cliFormatCross testConfig) pkgs crossPkgs;
+in
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "cross-zfs-${targetSystem}";
+  disko-config = ../example/cross-zfs.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  testMode = "direct";
+  testBoot = false;
+  extraTestScript = ''
+    machine.succeed("uname -m | grep -q x86_64")
+
+    print("Verifying host-native format script for ${targetSystem} target...")
+    machine.succeed("test -x ${hostFormatScript}/bin/disko-format")
+
+    def assert_property(ds, property, expected_value):
+        out = machine.succeed(f"zfs get -H {property} {ds} -o value").rstrip()
+        assert (
+            out == expected_value
+        ), f"Expected {property}={expected_value} on {ds}, got: {out}"
+
+    assert_property("zroot", "compression", "lz4")
+    assert_property("zroot", "com.sun:auto-snapshot", "false")
+
+    print("Cross-format test for ${targetSystem} completed successfully!")
+  '';
+}

--- a/tests/cross-zfs-armv7l.nix
+++ b/tests/cross-zfs-armv7l.nix
@@ -1,0 +1,42 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+let
+  lib = pkgs.lib;
+  targetSystem = "armv7l-linux";
+  crossAttr = "armv7l-hf-multiplatform";
+
+  diskoConfig = import ../example/cross-zfs.nix;
+  testConfig = diskoLib.testLib.prepareDiskoConfig diskoConfig (lib.tail diskoLib.testLib.devices);
+
+  tsp-generator = pkgs.callPackage ../. { checked = false; };
+  crossPkgs = pkgs.pkgsCross.${crossAttr};
+  hostFormatScript = (tsp-generator._cliFormatCross testConfig) pkgs crossPkgs;
+in
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "cross-zfs-${targetSystem}";
+  disko-config = ../example/cross-zfs.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  testMode = "direct";
+  testBoot = false;
+  extraTestScript = ''
+    machine.succeed("uname -m | grep -q x86_64")
+
+    print("Verifying host-native format script for ${targetSystem} target...")
+    machine.succeed("test -x ${hostFormatScript}/bin/disko-format")
+
+    def assert_property(ds, property, expected_value):
+        out = machine.succeed(f"zfs get -H {property} {ds} -o value").rstrip()
+        assert (
+            out == expected_value
+        ), f"Expected {property}={expected_value} on {ds}, got: {out}"
+
+    assert_property("zroot", "compression", "lz4")
+    assert_property("zroot", "com.sun:auto-snapshot", "false")
+
+    print("Cross-format test for ${targetSystem} completed successfully!")
+  '';
+}

--- a/tests/cross-zfs-i686.nix
+++ b/tests/cross-zfs-i686.nix
@@ -1,0 +1,42 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+let
+  lib = pkgs.lib;
+  targetSystem = "i686-linux";
+  crossAttr = "gnu32";
+
+  diskoConfig = import ../example/cross-zfs.nix;
+  testConfig = diskoLib.testLib.prepareDiskoConfig diskoConfig (lib.tail diskoLib.testLib.devices);
+
+  tsp-generator = pkgs.callPackage ../. { checked = false; };
+  crossPkgs = pkgs.pkgsCross.${crossAttr};
+  hostFormatScript = (tsp-generator._cliFormatCross testConfig) pkgs crossPkgs;
+in
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "cross-zfs-${targetSystem}";
+  disko-config = ../example/cross-zfs.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  testMode = "direct";
+  testBoot = false;
+  extraTestScript = ''
+    machine.succeed("uname -m | grep -q x86_64")
+
+    print("Verifying host-native format script for ${targetSystem} target...")
+    machine.succeed("test -x ${hostFormatScript}/bin/disko-format")
+
+    def assert_property(ds, property, expected_value):
+        out = machine.succeed(f"zfs get -H {property} {ds} -o value").rstrip()
+        assert (
+            out == expected_value
+        ), f"Expected {property}={expected_value} on {ds}, got: {out}"
+
+    assert_property("zroot", "compression", "lz4")
+    assert_property("zroot", "com.sun:auto-snapshot", "false")
+
+    print("Cross-format test for ${targetSystem} completed successfully!")
+  '';
+}

--- a/tests/cross-zfs-riscv64.nix
+++ b/tests/cross-zfs-riscv64.nix
@@ -1,0 +1,42 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+let
+  lib = pkgs.lib;
+  targetSystem = "riscv64-linux";
+  crossAttr = "riscv64";
+
+  diskoConfig = import ../example/cross-zfs.nix;
+  testConfig = diskoLib.testLib.prepareDiskoConfig diskoConfig (lib.tail diskoLib.testLib.devices);
+
+  tsp-generator = pkgs.callPackage ../. { checked = false; };
+  crossPkgs = pkgs.pkgsCross.${crossAttr};
+  hostFormatScript = (tsp-generator._cliFormatCross testConfig) pkgs crossPkgs;
+in
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "cross-zfs-${targetSystem}";
+  disko-config = ../example/cross-zfs.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  testMode = "direct";
+  testBoot = false;
+  extraTestScript = ''
+    machine.succeed("uname -m | grep -q x86_64")
+
+    print("Verifying host-native format script for ${targetSystem} target...")
+    machine.succeed("test -x ${hostFormatScript}/bin/disko-format")
+
+    def assert_property(ds, property, expected_value):
+        out = machine.succeed(f"zfs get -H {property} {ds} -o value").rstrip()
+        assert (
+            out == expected_value
+        ), f"Expected {property}={expected_value} on {ds}, got: {out}"
+
+    assert_property("zroot", "compression", "lz4")
+    assert_property("zroot", "com.sun:auto-snapshot", "false")
+
+    print("Cross-format test for ${targetSystem} completed successfully!")
+  '';
+}

--- a/tests/cross-zfs-x86_64.nix
+++ b/tests/cross-zfs-x86_64.nix
@@ -1,0 +1,42 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+let
+  lib = pkgs.lib;
+  targetSystem = "x86_64-linux";
+  crossAttr = "gnu64";
+
+  diskoConfig = import ../example/cross-zfs.nix;
+  testConfig = diskoLib.testLib.prepareDiskoConfig diskoConfig (lib.tail diskoLib.testLib.devices);
+
+  tsp-generator = pkgs.callPackage ../. { checked = false; };
+  crossPkgs = pkgs.pkgsCross.${crossAttr};
+  hostFormatScript = (tsp-generator._cliFormatCross testConfig) pkgs crossPkgs;
+in
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "cross-zfs-${targetSystem}";
+  disko-config = ../example/cross-zfs.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  testMode = "direct";
+  testBoot = false;
+  extraTestScript = ''
+    machine.succeed("uname -m | grep -q x86_64")
+
+    print("Verifying host-native format script for ${targetSystem} target...")
+    machine.succeed("test -x ${hostFormatScript}/bin/disko-format")
+
+    def assert_property(ds, property, expected_value):
+        out = machine.succeed(f"zfs get -H {property} {ds} -o value").rstrip()
+        assert (
+            out == expected_value
+        ), f"Expected {property}={expected_value} on {ds}, got: {out}"
+
+    assert_property("zroot", "compression", "lz4")
+    assert_property("zroot", "com.sun:auto-snapshot", "false")
+
+    print("Cross-format test for ${targetSystem} completed successfully!")
+  '';
+}


### PR DESCRIPTION
Add cross-compilation support for disk formatting (ZFS)
When formatting disks for a different target architecture (e.g.,
creating an aarch64 disk image from an x86_64 host), tools like ZFS that
communicate with kernel modules must use host-native binaries.

I am guessing there also exist other cases when ZFS comes into play.

This is not a problem with tools like `ext4` because they do everything
in user space.

I have created an example file and used it to build the file system for
the archs `aarch64`, `armv7l`, `i686`, `riscv64` and `x86_64`.

**Note:** The host system must have the following nixos configs enabled.

```nix
# `preferStaticEmulators` is need or the activation script in chroot
# cannot be executed because it is a different arch when the host system
boot.binfmt.preferStaticEmulators = true;
boot.binfmt.emulatedSystems = [ "<TARGET_ARCH>" ];
```

**Update: 2026-03-04**

If you get the following error when trying out this patch:

```text
error:
       … from call site
         at /nix/store/kl1z5wlb7cb77l68l8a7n6486c2ki4qm-disko/share/disko/install-cli.nix:67:13:
           66|   # that can communicate with the running kernel
           67|   scripts = diskoSystem.config.disko.devices._scripts {
             |             ^
           68|     pkgs = diskoSystem.pkgs; # target pkgs for mount scripts
       error: function 'default' called with unexpected argument 'hostPkgs'
       at /nix/store/zaz0bhdxnm77pvnwn0y07df87b3r97sj-source/lib/default.nix:721:15:
          720|             default =
          721|               {
             |               ^
          722|                 pkgs,
Failed to build NixOS configuration 
```

When it happens because the disko version used in your flake input of the system you are trying to build is from upstream. You need to use this for your flake inputs:

```nix
...
    disko = {
      url = "github:nix-community/disko?ref=pull/1190/merge";
      inputs.nixpkgs.follows = "nixpkgs";
    };
...
```

I just bumped into this problem today and was quite confused for some time.