### PR TITLE
fix luks askPassword loop

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -148,7 +148,7 @@ in
                 promptSecret "Enter password for ${config.device} again to be safe: " password_check
                 export password
                 if [ "$password" != "$password_check" ]; then
-                  exit 1
+                  return 1
                 fi
                 set -x
               else


### PR DESCRIPTION
user is not reprompted if password != password_check. happened to me once :)
solution: use bash return in function instead of exit