### PR TITLE
lib: luks.create: handle interactive password for existing devices

### DIFF
--- a/lib/types/luks.nix
+++ b/lib/types/luks.nix
@@ -160,6 +160,16 @@ in
             done
           ''}
           cryptsetup -q luksFormat "${config.device}" ${toString config.extraFormatArgs} ${keyFileArgs}
+        else
+          if [ -z ''${IN_DISKO_TEST+x} ]; then
+            set +x
+            echo "Enter password for ${config.device}"
+            IFS= read -r -s password
+            export password
+            set -x
+          else
+            export password=disko
+          fi
         fi
 
         if ! cryptsetup status "${config.name}" >/dev/null; then


### PR DESCRIPTION
Otherwise `format,mount` mode fails when using interactive password for existing devices (that don't need to be touched)