### PR TITLE
Support more disks in VM

### DIFF
--- a/example/zfs-multi-raidz3.nix
+++ b/example/zfs-multi-raidz3.nix
@@ -1,0 +1,92 @@
+{
+  disko.devices = {
+    disk = {
+      boot = {
+        type = "disk";
+        device = "/dev/vda";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "64M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
+              };
+            };
+          };
+        };
+      };
+    }
+    // (builtins.listToAttrs (
+      builtins.genList (i: {
+        name = "disk${toString i}";
+        value = {
+          type = "disk";
+          device = "/dev/sd${
+            if i < 26 then
+              builtins.substring i 1 "abcdefghijklmnopqrstuvwxyz"
+            else
+              "a${builtins.substring (i - 26) 1 "abcdefghijklmnopqrstuvwxyz"}"
+          }";
+          content = {
+            type = "gpt";
+            partitions = {
+              zfs = {
+                size = "100%";
+                content = {
+                  type = "zfs";
+                  pool = "zroot";
+                };
+              };
+            };
+          };
+        };
+      }) 36
+    ));
+    zpool = {
+      zroot = {
+        type = "zpool";
+        mode = {
+          topology = {
+            type = "topology";
+            vdev = [
+              # First raidz3 group: disks 0-10 (11 disks)
+              {
+                mode = "raidz3";
+                members = builtins.genList (i: "disk${toString i}") 11;
+              }
+              # Second raidz3 group: disks 11-21 (11 disks)
+              {
+                mode = "raidz3";
+                members = builtins.genList (i: "disk${toString (i + 11)}") 11;
+              }
+              # Third raidz3 group: disks 22-32 (11 disks)
+              {
+                mode = "raidz3";
+                members = builtins.genList (i: "disk${toString (i + 22)}") 11;
+              }
+            ];
+            # 3 hot spares: disks 33-35
+            spare = builtins.genList (i: "disk${toString (i + 33)}") 3;
+          };
+        };
+        rootFsOptions = {
+          compression = "zstd";
+          "com.sun:auto-snapshot" = "false";
+        };
+        mountpoint = "/";
+        datasets = {
+          zfs_fs = {
+            type = "zfs_fs";
+            mountpoint = "/zfs_fs";
+            options."com.sun:auto-snapshot" = "true";
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/interactive-vm.nix
+++ b/lib/interactive-vm.nix
@@ -34,10 +34,11 @@ let
     deviceExtraOpts.bootindex = "1";
     deviceExtraOpts.serial = "root";
   };
-  otherDisks = map (disk: {
+  otherDisks = lib.imap0 (i: disk: {
     name = disk.name;
     file = ''"$tmp"/${lib.escapeShellArg disk.imageName}.qcow2'';
     driveExtraOpts.werror = "report";
+    deviceExtraOpts.bus = "bridge${toString (i / 31 + 1)}";
   }) (builtins.tail disks);
 
   diskoBasedConfiguration = {
@@ -68,6 +69,19 @@ in
   virtualisation.useDefaultFilesystems = false;
   virtualisation.diskImage = null;
   virtualisation.qemu.drives = [ rootDisk ] ++ otherDisks;
+
+  # Using `networkingOptions` instead of `options` here because it's added _before_ the drive options, where `options` is added at the end :-P
+  virtualisation.qemu.networkingOptions = lib.mkAfter (
+    let
+      # A PCI bridge takes one slot and adds 32, so we'll want one for every 31 drives
+      count = ((builtins.length otherDisks) + 30) / 31;
+      parentBridge = i: lib.optionalString (i > 0) "bus=bridge${toString i},";
+    in
+    (builtins.genList (
+      i: "-device pci-bridge,id=bridge${toString (i + 1)},${parentBridge i}chassis_nr=${toString (i + 1)}"
+    ) count)
+  );
+
   boot.zfs.devNodes = "/dev/disk/by-uuid"; # needed because /dev/disk/by-id is empty in qemu-vms
   boot.zfs.forceImportAll = true;
   boot.zfs.forceImportRoot = lib.mkForce true;

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -50,23 +50,11 @@ let
       };
 
     # list of devices generated inside qemu
-    devices = [
-      "/dev/vda"
-      "/dev/vdb"
-      "/dev/vdc"
-      "/dev/vdd"
-      "/dev/vde"
-      "/dev/vdf"
-      "/dev/vdg"
-      "/dev/vdh"
-      "/dev/vdi"
-      "/dev/vdj"
-      "/dev/vdk"
-      "/dev/vdl"
-      "/dev/vdm"
-      "/dev/vdn"
-      "/dev/vdo"
-    ];
+    devices =
+      let
+        chars = lib.stringToCharacters "abcdefghijklmnopqrstuvwxyz";
+      in
+      (map (c: "/dev/vd${c}") chars) ++ (lib.concatMap (c1: map (c2: "/dev/vd${c1}${c2}") chars) chars);
 
     # This is the test generator for a disko test
     makeDiskoTest =
@@ -301,11 +289,27 @@ let
             ) testConfigInstall.networking.hostId;
 
             virtualisation = {
-              emptyDiskImages = builtins.genList (_: 4096) num-disks;
+              emptyDiskImages = builtins.genList (i: {
+                size = 4096;
+                driveConfig.deviceExtraOpts.bus = "bridge${toString (i / 31 + 1)}";
+              }) num-disks;
+
               qemu.options = lib.mkIf enableCanokey [
                 "-device pci-ohci,id=usb-bus"
                 "-device canokey,bus=usb-bus.0,file=/tmp/canokey-file"
               ];
+
+              # Using `networkingOptions` instead of `options` here because it's added _before_ the drive options, where `options` is added at the end :-P
+              qemu.networkingOptions = lib.mkAfter (
+                let
+                  # A PCI bridge takes one slot and adds 32, so we'll want one for every 31 drives
+                  count = (num-disks + 30) / 31;
+                  parentBridge = i: lib.optionalString (i > 0) "bus=bridge${toString i},";
+                in
+                (builtins.genList (
+                  i: "-device pci-bridge,id=bridge${toString (i + 1)},${parentBridge i}chassis_nr=${toString (i + 1)}"
+                ) count)
+              );
 
               # REMOVEME when Canokey support is enabled upstream
               qemu.package = lib.mkForce qemuPkg;
@@ -322,12 +326,17 @@ let
 
             def disks(oldmachine, num_disks):
                 disk_flags = []
+                for i in range((num_disks + 30) // 31):
+                    disk_flags += [
+                      '-device',
+                      f"pci-bridge,id=bridge{i + 1},{f'bus=bridge{i},' if i > 0 else '''}chassis_nr={i + 1}"
+                    ]
                 for i in range(num_disks):
                     disk_flags += [
                       '-drive',
                       f"file={oldmachine.state_dir}/empty{i}.qcow2,id=drive{i + 1},if=none,index={i + 1},werror=report",
                       '-device',
-                      f"virtio-blk-pci,drive=drive{i + 1}"
+                      f"virtio-blk-pci,bus=bridge{i // 31 + 1},drive=drive{i + 1}"
                     ]
                 return disk_flags
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -22,6 +22,7 @@ let
   );
   incompatibleTests = lib.optionals pkgs.stdenv.buildPlatform.isRiscV64 [
     "zfs"
+    "zfs-multi-raidz3"
     "zfs-over-legacy"
     "cli"
     "module"

--- a/tests/zfs-multi-raidz3.nix
+++ b/tests/zfs-multi-raidz3.nix
@@ -1,0 +1,55 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "zfs-multi-raidz3";
+  disko-config = ../example/zfs-multi-raidz3.nix;
+  extraInstallerConfig.networking.hostId = "8425e349";
+  extraSystemConfig.networking.hostId = "8425e349";
+  extraTestScript = ''
+    def assert_property(ds, property, expected_value):
+        out = machine.succeed(f"zfs get -H {property} {ds} -o value").rstrip()
+        assert (
+            out == expected_value
+        ), f"Expected {property}={expected_value} on {ds}, got: {out}"
+
+    assert_property("zroot", "compression", "zstd")
+    assert_property("zroot/zfs_fs", "com.sun:auto-snapshot", "true")
+    assert_property("zroot/zfs_fs", "compression", "zstd")
+    machine.succeed("mountpoint /zfs_fs");
+
+    # Verify the pool has 36 devices total (33 in raidz3 vdevs + 3 spares)
+    status_output = machine.succeed("zpool status -P zroot")
+
+    # Count the number of disk devices in the pool
+    device_count = 0
+    for line in status_output.split("\n"):
+        if "/dev/" in line:
+            device_count += 1
+
+    assert device_count == 36, f"Expected 36 devices in pool, found {device_count}"
+
+    # Verify we have 3 raidz3 vdevs
+    raidz3_count = status_output.count("raidz3")
+    assert raidz3_count == 3, f"Expected 3 raidz3 vdevs, found {raidz3_count}"
+
+    # Verify we have 3 spares
+    spares_count = 0
+    in_spares_section = False
+    for line in status_output.split("\n"):
+        if line.strip().startswith("spares"):
+            in_spares_section = True
+        elif in_spares_section and "/dev/" in line:
+            spares_count += 1
+        elif in_spares_section and line.strip() and not line.startswith("\t"):
+            in_spares_section = False
+
+    assert spares_count == 3, f"Expected 3 spare devices, found {spares_count}"
+
+    # Verify pool health
+    pool_state = machine.succeed("zpool list -H -o health zroot").strip()
+    assert pool_state == "ONLINE", f"Expected pool health ONLINE, got {pool_state}"
+  '';
+}


### PR DESCRIPTION
This adds support for much larger numbers of disks in VMs. In my case, I wanted this so I could verify a config before deploying to a multi-array server.

The core limitation is that qemu virtio-blk-pci disks occupy a PCI slot each, and a large array can quickly exhaust available slots. This uses a PCI-to-PCI bridge to add another 32 slots, and, if we have more than 31 disks, starts daisy-chaining more bridges onto that.

- Expanded the device name list up to `/dev/vdzz`
- Added a PCI bridge (or a daisy chain of them), and added flags to each disk device to attach it to the appropriate bridge
- Added an example with a zpool with 36 disks to test/demonstrate