### PR TITLE
Escape ZFS args

### DIFF
--- a/lib/types/zfs_fs.nix
+++ b/lib/types/zfs_fs.nix
@@ -91,12 +91,14 @@
           updateOptions = builtins.removeAttrs createOptions onetimeProperties;
         in
         ''
-          if ! zfs get type ${config._name} >/dev/null 2>&1; then
+          if ! zfs get type "${config._name}" >/dev/null 2>&1; then
             ${
               if config._createFilesystem then
                 ''
-                  zfs create -up ${config._name} \
-                    ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") (createOptions))}
+                  zfs create -up "${config._name}" \
+                    ${lib.concatStringsSep " " (
+                      lib.mapAttrsToList (n: v: "-o ${n}=${lib.escapeShellArg v}") (createOptions)
+                    )}
                 ''
               else
                 ''
@@ -107,8 +109,8 @@
           ${lib.optionalString (updateOptions != { }) ''
             else
               zfs set -u ${
-                lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${v}") updateOptions)
-              } ${config._name}
+                lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") updateOptions)
+              } "${config._name}"
           ''}
           fi
         '';

--- a/lib/types/zfs_volume.nix
+++ b/lib/types/zfs_volume.nix
@@ -63,7 +63,11 @@
       default = ''
         if ! zfs get type "${config._parent.name}/${config.name}" >/dev/null 2>&1; then
           zfs create "${config._parent.name}/${config.name}" \
-            ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
+            ${
+              lib.concatStringsSep " " (
+                lib.mapAttrsToList (n: v: "-o ${n}=${lib.escapeShellArg v}") config.options
+              )
+            } \
             -V ${config.size} ${toString (builtins.map lib.escapeShellArg config.extraArgs)}
           zvol_wait
           partprobe "/dev/zvol/${config._parent.name}/${config.name}"

--- a/lib/types/zpool.nix
+++ b/lib/types/zpool.nix
@@ -377,8 +377,16 @@ in
                   else
                     ""
                 } \
-                ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-o ${n}=${v}") config.options)} \
-                ${lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "-O ${n}=${v}") config.rootFsOptions)} \
+                ${
+                  lib.concatStringsSep " " (
+                    lib.mapAttrsToList (n: v: "-o ${n}=${lib.escapeShellArg v}") config.options
+                  )
+                } \
+                ${
+                  lib.concatStringsSep " " (
+                    lib.mapAttrsToList (n: v: "-O ${n}=${lib.escapeShellArg v}") config.rootFsOptions
+                  )
+                } \
                 ''${topology:+ $topology}
               if [[ $(zfs get -H mounted "${config.name}" | cut -f3) == "yes" ]]; then
                 zfs unmount "${config.name}"


### PR DESCRIPTION
Args to ZFS (like mountpoints) might have spaces or other shell-unfriendly characters in them. This escapes those so they get passed to zfs correctly.