### PR TITLE
Add simple zfs example and make-disk-image test for it

### DIFF
--- a/example/zfs-simple-root.nix
+++ b/example/zfs-simple-root.nix
@@ -1,0 +1,73 @@
+{
+  disko.devices = {
+    disk = {
+      disk1 = {
+        device = "/dev/disk/sdx";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              type = "EF00";
+              size = "2G";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "rpool";
+              };
+            };
+          };
+        };
+      };
+    };
+    zpool = {
+      rpool = {
+        type = "zpool";
+        rootFsOptions = {
+          acltype = "posixacl";
+          compression = "zstd";
+          dnodesize = "auto";
+          normalization = "formD";
+          relatime = "on";
+          xattr = "sa";
+        };
+        options = {
+          ashift = "12";
+          autotrim = "on";
+        };
+
+        datasets = {
+          "root" = {
+            type = "zfs_fs";
+            options = {
+              mountpoint = "legacy";
+            };
+            mountpoint = "/";
+          };
+          "nix" = {
+            type = "zfs_fs";
+            options.mountpoint = "legacy";
+            mountpoint = "/nix";
+          };
+          "var" = {
+            type = "zfs_fs";
+            options.mountpoint = "legacy";
+            mountpoint = "/var";
+          };
+          "home" = {
+            type = "zfs_fs";
+            mountpoint = "/home";
+            options.mountpoint = "legacy";
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/make-disk-image-zfs.nix
+++ b/tests/make-disk-image-zfs.nix
@@ -1,0 +1,26 @@
+{
+  pkgs ? import <nixpkgs> { },
+  ...
+}:
+
+(pkgs.nixos [
+  ../module.nix
+  ../example/zfs-simple-root.nix
+  (
+    { config, ... }:
+    {
+      networking.hostId = "00000000";
+
+      # Adds some weight to the closure size to test real world usage
+      disko.devices.disk.disk1.imageSize = "5G";
+      environment.systemPackages = with pkgs; [
+        chromium
+        firefox
+      ];
+
+      documentation.enable = false;
+      system.stateVersion = config.system.nixos.release;
+      disko.checkScripts = true;
+    }
+  )
+]).config.system.build.diskoImages


### PR DESCRIPTION
This test and example is good to keep track of. The example is how I actually use disko on my own setups, and I think it's a good starter template to get the most out of ZFS in the real world, and worth sharing. Can refine if there is disagreement on some of the values.

The long standing dreaded "cp: Cannot allocate memory"  issue seems to be limited to ZFS, and can only be reproduced at the moment on kernel 6.19, and not the default kernelPackages, which is set to LTS 6.12.

To reproduce that issue, add `boot.kernelPackages = pkgs.linuxPackages_6_19;` to `tests/make-disk-image-zfs.nix` like so:

```diff
diff --git a/tests/make-disk-image-zfs.nix b/tests/make-disk-image-zfs.nix
index 823023c..f4cf1a6 100644
--- a/tests/make-disk-image-zfs.nix
+++ b/tests/make-disk-image-zfs.nix
@@ -9,6 +9,7 @@
   (
     { config, ... }:
     {
+      boot.kernelPackages = pkgs.linuxPackages_6_19;
       networking.hostId = "00000000";
       disko.devices.disk.disk1.imageSize = "5G";
       environment.systemPackages = with pkgs; [
```