### PR TITLE
Show error when attempting to create bcachefs subvolume in place of dir

### DIFF
--- a/lib/types/bcachefs_filesystem.nix
+++ b/lib/types/bcachefs_filesystem.nix
@@ -203,12 +203,9 @@
                 SUBVOL_ABS_PATH="$MNTPOINT/${subvolume.name}";
                 # Check if it's already a subvolume (using snapshot).
                 if ! bcachefs subvolume snapshot "$SUBVOL_ABS_PATH" "$TEMPDIR/" >&2 2>&1; then
-                  # It's not a subvolume, now check if it's a directory.
-                  if ! test -d "$SUBVOL_ABS_PATH"; then
-                    # It's not a subvolume AND not a directory, so create it.
-                    mkdir -p -- "$(dirname -- "$SUBVOL_ABS_PATH")";
-                    bcachefs subvolume create "$SUBVOL_ABS_PATH";
-                  fi
+                  # Attempt to create the subvolume otherwise.
+                  mkdir -p -- "$(dirname -- "$SUBVOL_ABS_PATH")";
+                  bcachefs subvolume create "$SUBVOL_ABS_PATH";
                 fi;
               )
             '') (lib.attrValues config.subvolumes)}


### PR DESCRIPTION
The bcachefs module currently silently skips subvolume creation if there is already a directory present at the given path. As far as I can tell disko most likely never hits that condition, but if it does should most likely fail/print the error. The bcachefs tools already fail and print an error when attempting to create a subvolume in a place where there is already a directory, so the additional check in disko can just be removed.