### PR TITLE
make-disk-image: don't build native `/etc`, only the udev rules.

### DIFF
--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -124,7 +124,7 @@ let
     ln -sfn /proc/self/fd/2 /dev/stderr
     mkdir -p /etc/udev
     mount -t efivarfs none /sys/firmware/efi/efivars
-    ln -sfn ${systemToInstallNative.config.system.build.etc}/etc/udev/rules.d /etc/udev/rules.d
+    ln -sfn ${systemToInstallNative.config.environment.etc."udev/rules.d".source} /etc/udev/rules.d
     mkdir -p /dev/.mdadm
     ${pkgs.systemdMinimal}/lib/systemd/systemd-udevd --daemon
     partprobe


### PR DESCRIPTION
This is a very simple change that should mostly address #988 and #1062 without a new option or changing behavior.