### PR TITLE
docs: fix upgrade guide link pointing to a fork

### DIFF
--- a/docs/HowTo.md
+++ b/docs/HowTo.md
@@ -9,7 +9,7 @@ TODO: Still to be documented
 TODO: Include documentation here.
 
 For now, see the
-[upgrade guide](https://github.com/JillThornhill/disko/blob/master/docs/upgrade-guide.md)
+[upgrade guide](./upgrade-guide.md)
 
 ## Installing NixOS module
 


### PR DESCRIPTION
Fixes #1245

The "upgrade guide" link in `docs/HowTo.md` pointed to
`github.com/JillThornhill/disko/blob/master/docs/upgrade-guide.md` (a
fork) instead of the canonical `docs/upgrade-guide.md`, which already
exists in this repo. Changed it to a relative link.