### PR TITLE
make-disk-image: Fix overriding kernel modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780930886,
-        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -41,6 +41,7 @@ let
       ]
       ++ (lib.optional configSupportsZfs "zfs")
       ++ cfg.extraRootModules;
+      kernel = cfg.kernelPackages.kernel;
       kernelModules = pkgs.aggregateModules (
         [
           cfg.kernelPackages.kernel

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -41,7 +41,7 @@ let
       ]
       ++ (lib.optional configSupportsZfs "zfs")
       ++ cfg.extraRootModules;
-      kernel = pkgs.aggregateModules (
+      kernelModules = pkgs.aggregateModules (
         [
           cfg.kernelPackages.kernel
         ]


### PR DESCRIPTION
After [#530764](https://github.com/NixOS/nixpkgs/pull/530764) PR kernel modules should be passed as `kernelModules` instead of `kernel`.

Fixes error:
```
… while evaluating definitions from `/nix/store/1c1jbpjisa2249vrffd97vmjdflbcprx-source/lib/make-disk-image.nix':

(stack trace truncated; use '--show-trace' to show the full, detailed trace)

error: vmTools: the `kernel` argument (kernel-modules) has no
`target` attribute, so the kernel image filename cannot be determined.

If you are passing a module tree (e.g. from `pkgs.aggregateModules`) to
make extra modules available, pass it via `kernelModules` instead and
keep `kernel` pointing at a real kernel derivation. Alternatively, pass
`kernelImage` explicitly with the path of the bootable image relative
to the `kernel` derivation output (e.g. "bzImage" or "Image").
```

This should also fixes tests in [#1273](https://github.com/nix-community/disko/pull/1273) PR