### PR TITLE
luks: add test for multiple partitions and fix handling if on same disk

### DIFF
--- a/example/luks-multiple.nix
+++ b/example/luks-multiple.nix
@@ -1,0 +1,65 @@
+{
+  disko.devices = {
+    disk = {
+      main = {
+        type = "disk";
+        device = "/dev/vdb";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "500M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [ "umask=0077" ];
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "luks";
+                name = "root";
+                extraOpenArgs = [ ];
+                settings = {
+                  # if you want to use the key for interactive login be sure there is no trailing newline
+                  # for example use `echo -n "password" > /tmp/secret.key`
+                  keyFile = "/tmp/secret.key";
+                  allowDiscards = true;
+                };
+                additionalKeyFiles = [ "/tmp/additionalSecret.key" ];
+                content = {
+                  type = "filesystem";
+                  format = "ext4";
+                  mountpoint = "/";
+                };
+              };
+            };
+            home = {
+              size = "100M";
+              content = {
+                type = "luks";
+                name = "home";
+                extraOpenArgs = [ ];
+                settings = {
+                  # if you want to use the key for interactive login be sure there is no trailing newline
+                  # for example use `echo -n "password" > /tmp/secret.key`
+                  keyFile = "/tmp/secret.key";
+                  allowDiscards = true;
+                };
+                additionalKeyFiles = [ "/tmp/additionalSecret.key" ];
+                content = {
+                  type = "filesystem";
+                  format = "ext4";
+                  mountpoint = "/home";
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -82,6 +82,8 @@ let
         efi ? !pkgs.stdenv.hostPlatform.isRiscV64,
         enableCanokey ? false,
         postDisko ? "",
+        postUnmountPreMount ? "",
+        postMount ? "",
         testMode ? "module", # can be one of direct module cli
         testBoot ? true, # if we actually want to test booting or just create/mount
         enableOCR ? false,
@@ -369,7 +371,9 @@ let
               machine.succeed("${lib.getExe tsp-mount}") # verify that mount is idempotent
               machine.succeed("${lib.getExe tsp-unmount}")
               machine.succeed("${lib.getExe tsp-unmount}") # verify that umount is idempotent
+              ${postUnmountPreMount}
               machine.succeed("${lib.getExe tsp-mount}") # verify that mount is idempotent
+              ${postMount}
               machine.succeed("${lib.getExe tsp-disko} --yes-wipe-all-disks") # verify that we can destroy and recreate
               machine.succeed("mkdir -p /mnt/home")
               machine.succeed("touch /mnt/home/testfile")
@@ -383,7 +387,9 @@ let
               machine.succeed("${lib.getExe nodes.machine.system.build.mount}") # verify that mount is idempotent
               machine.succeed("${lib.getExe nodes.machine.system.build.unmount}")
               machine.succeed("${lib.getExe nodes.machine.system.build.unmount}") # verify that unmount is idempotent
+              ${postUnmountPreMount}
               machine.succeed("${lib.getExe nodes.machine.system.build.mount}") # verify that mount is idempotent
+              ${postMount}
               machine.succeed("${lib.getExe nodes.machine.system.build.destroyFormatMount} --yes-wipe-all-disks") # verify that we can destroy and recreate again
               machine.succeed("mkdir -p /mnt/home")
               machine.succeed("touch /mnt/home/testfile")

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -342,30 +342,24 @@ in
       inherit config options;
       default =
         let
-          partMounts = lib.foldr lib.recursiveUpdate { } (
-            map (partition: lib.optionalAttrs (partition.content != null) partition.content._mount) (
-              lib.attrValues config.partitions
-            )
-          );
+          activePartitions = lib.filter (p: p.content != null) (lib.attrValues config.partitions);
+          mounts = map (p: p.content._mount) activePartitions;
         in
         {
-          dev = partMounts.dev or "";
-          fs = partMounts.fs or { };
+          dev = lib.concatStringsSep "\n" (map (m: m.dev or "") mounts);
+          fs = lib.foldr lib.recursiveUpdate { } (map (m: m.fs or { }) mounts);
         };
     };
     _unmount = diskoLib.mkUnmountOption {
       inherit config options;
       default =
         let
-          partMounts = lib.foldr lib.recursiveUpdate { } (
-            map (partition: lib.optionalAttrs (partition.content != null) partition.content._unmount) (
-              lib.attrValues config.partitions
-            )
-          );
+          activePartitions = lib.filter (p: p.content != null) (lib.attrValues config.partitions);
+          unmounts = map (p: p.content._unmount) activePartitions;
         in
         {
-          dev = partMounts.dev or "";
-          fs = partMounts.fs or { };
+          dev = lib.concatStringsSep "\n" (map (m: m.dev or "") unmounts);
+          fs = lib.foldr lib.recursiveUpdate { } (map (m: m.fs or { }) unmounts);
         };
     };
     _config = lib.mkOption {

--- a/tests/luks-multiple.nix
+++ b/tests/luks-multiple.nix
@@ -1,0 +1,22 @@
+{
+  pkgs ? import <nixpkgs> { },
+  diskoLib ? pkgs.callPackage ../lib { },
+}:
+diskoLib.testLib.makeDiskoTest {
+  inherit pkgs;
+  name = "luks-multiple";
+  disko-config = ../example/luks-multiple.nix;
+  testBoot = false;
+  postUnmountPreMount = ''
+    machine.fail("mountpoint /mnt/");
+    machine.fail("mountpoint /mnt/home");
+    machine.fail("${pkgs.cryptsetup}/bin/cryptsetup status root")
+    machine.fail("${pkgs.cryptsetup}/bin/cryptsetup status home")
+  '';
+  postMount = ''
+    machine.succeed("mountpoint /mnt/");
+    machine.succeed("mountpoint /mnt/home");
+    machine.succeed("${pkgs.cryptsetup}/bin/cryptsetup status root")
+    machine.succeed("${pkgs.cryptsetup}/bin/cryptsetup status home")
+  '';
+}


### PR DESCRIPTION
This PR addresses the handling of multiple LUKS partitions on the same disk and adds a corresponding test case.

- **Fix:** The core logic for handling multiple LUKS partitions on a single disk was improved to ensure correct partition mapping and unlocking. (Implemented using a custom pi agent and the **mimo-v2.5** model).
- **Tests:** Added `luks-multiple` test to verify the behavior of multiple LUKS partitions on the same disk. (Tests written by me).

Reproduces and fixes #1263 