### PR TITLE
gpt: reject '0<unit>' partition start values that crash sgdisk

### DIFF
--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -183,9 +183,19 @@ in
                 description = "Alignment of the partition, if sectors are used as start or end it can be aligned to 1";
               };
               start = lib.mkOption {
-                type = lib.types.str;
+                type = lib.types.addCheck lib.types.str (
+                  start: builtins.match "[+-]?0+[KMGTP]" start == null
+                );
                 default = "0";
-                description = "Start of the partition, in sgdisk format, use 0 for next available range";
+                description = ''
+                  Start of the partition, in sgdisk format, use 0 for next available range.
+
+                  Note: sgdisk treats a bare "0" as "next available range", but "0"
+                  followed directly by a size unit (e.g. "0M") is a literal
+                  zero-byte offset that collides with the GPT header, causing a
+                  confusing sgdisk failure. Use a bare "0" or a non-zero offset
+                  (e.g. "1M") instead.
+                '';
               };
               end = lib.mkOption {
                 type = lib.types.str;

--- a/lib/types/gpt.nix
+++ b/lib/types/gpt.nix
@@ -183,7 +183,10 @@ in
                 description = "Alignment of the partition, if sectors are used as start or end it can be aligned to 1";
               };
               start = lib.mkOption {
-                type = lib.types.addCheck lib.types.str (
+                # addCheck isn't in disko's jsonTypes doc-generation stub lib,
+                # so fall back to a no-op there instead of crashing; real
+                # evaluation always has the genuine addCheck.
+                type = (lib.types.addCheck or (elemType: _check: elemType)) lib.types.str (
                   start: builtins.match "[+-]?0+[KMGTP]" start == null
                 );
                 default = "0";


### PR DESCRIPTION
`sgdisk` treats a bare `"0"` for `start` as "next available range", but `"0"` directly followed by a size unit (`0M`, `0K`, `0G`, `0T`, `0P`) is parsed as a literal zero-byte offset instead, which collides with the GPT header/table area and makes `sgdisk` fail with a confusing error instead of doing what the user expects (see the errors quoted in the issue).

This adds a type check on the `start` option (`lib/types/gpt.nix`), following the same pattern used by the `size` option a few lines above, that rejects this specific footgun at Nix-eval time with a clear description, while still allowing a bare `"0"` and any non-zero offset (e.g. `"1M"`, `"2048"`, `"-1M"`).

Checked all in-repo usages of `start` on gpt-typed partitions (examples and tests): they all use non-zero offsets like `"1M"` already, so this shouldn't affect any existing configuration.

I don't have a local Nix environment to run `nix flake check` / the test suite against this change, so flagging that so a maintainer/CI can verify the syntax and formatting (`nixfmt`) directly.

Fixes #702