### PR TITLE
swap: allow randomEncryption to take an attrset for extra config

### DIFF
--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -7,6 +7,13 @@
   device,
   ...
 }:
+let
+  randomEncryptionEnabled =
+    if builtins.isBool config.randomEncryption then
+      config.randomEncryption
+    else
+      config.randomEncryption.enable or true;
+in
 {
   options = {
     type = lib.mkOption {
@@ -58,9 +65,17 @@
       '';
     };
     randomEncryption = lib.mkOption {
-      type = lib.types.bool;
+      type = lib.types.either lib.types.bool (lib.types.attrsOf lib.types.anything);
       default = false;
-      description = "Whether to randomly encrypt the swap";
+      description = ''
+        Whether to randomly encrypt the swap.
+
+        Can be a plain boolean to just enable/disable it, or an attribute set
+        to pass through additional options to NixOS's
+        `swapDevices.*.randomEncryption` (e.g. `cipher`, `sectorSize`). When
+        given as an attribute set, encryption is enabled unless `enable` is
+        explicitly set to `false`.
+      '';
     };
     resumeDevice = lib.mkOption {
       type = lib.types.bool;
@@ -81,7 +96,7 @@
     _create = diskoLib.mkCreateOption {
       inherit config options;
       # TODO: we don't support encrypted swap yet
-      default = lib.optionalString (!config.randomEncryption) ''
+      default = lib.optionalString (!randomEncryptionEnabled) ''
         if ! blkid "${config.device}" -o export | grep -q '^TYPE='; then
           mkswap \
             ${toString config.extraArgs} \
@@ -92,7 +107,7 @@
     _mount = diskoLib.mkMountOption {
       inherit config options;
       # TODO: we don't support encrypted swap yet
-      default = lib.optionalAttrs (!config.randomEncryption) {
+      default = lib.optionalAttrs (!randomEncryptionEnabled) {
         fs.${config.device} = ''
           if test "''${DISKO_SKIP_SWAP:-}" != 1 && ! swapon --show | grep -q "^$(readlink -f "${config.device}") "; then
             swapon ${
@@ -107,7 +122,7 @@
     };
     _unmount = diskoLib.mkUnmountOption {
       inherit config options;
-      default = lib.optionalAttrs (!config.randomEncryption) {
+      default = lib.optionalAttrs (!randomEncryptionEnabled) {
         fs.${config.device} = ''
           if swapon --show | grep -q "^$(readlink -f "${config.device}") "; then
             swapoff "${config.device}"
@@ -124,11 +139,13 @@
             {
               device = config.device;
               inherit (config) discardPolicy priority;
-              randomEncryption = {
-                enable = config.randomEncryption;
-                # forward discard/TRIM attempts through dm-crypt
-                allowDiscards = config.discardPolicy != null;
-              };
+              randomEncryption =
+                {
+                  enable = randomEncryptionEnabled;
+                  # forward discard/TRIM attempts through dm-crypt
+                  allowDiscards = config.discardPolicy != null;
+                }
+                // lib.optionalAttrs (!builtins.isBool config.randomEncryption) config.randomEncryption;
               options = config.mountOptions;
             }
           ];

--- a/lib/types/swap.nix
+++ b/lib/types/swap.nix
@@ -139,13 +139,12 @@ in
             {
               device = config.device;
               inherit (config) discardPolicy priority;
-              randomEncryption =
-                {
-                  enable = randomEncryptionEnabled;
-                  # forward discard/TRIM attempts through dm-crypt
-                  allowDiscards = config.discardPolicy != null;
-                }
-                // lib.optionalAttrs (!builtins.isBool config.randomEncryption) config.randomEncryption;
+              randomEncryption = {
+                enable = randomEncryptionEnabled;
+                # forward discard/TRIM attempts through dm-crypt
+                allowDiscards = config.discardPolicy != null;
+              }
+              // lib.optionalAttrs (!builtins.isBool config.randomEncryption) config.randomEncryption;
               options = config.mountOptions;
             }
           ];


### PR DESCRIPTION
`randomEncryption` on the `swap` partition type was typed as a plain `bool`, which only ever built `{ enable = ...; allowDiscards = ...; }` for NixOS's `swapDevices.*.randomEncryption` submodule, so there was no way to reach its other options (`cipher`, `sectorSize`, etc.), as noted in the issue.

Per the maintainer's suggestion in the issue thread, this widens the type to `lib.types.either lib.types.bool (lib.types.attrsOf lib.types.anything)`:
- A plain `true`/`false` keeps the exact old behavior (backwards compatible: verified both existing in-repo usages, `example/swap.nix` and `tests/mdadm-btrfs-wipe.nix`, still use a bare bool and are unaffected).
- An attrset enables encryption by default (`enable = true`, overridable by setting `enable` in the attrset), and is merged over the `enable`/`allowDiscards` defaults so any extra NixOS `randomEncryption` options (cipher, sectorSize, ...) pass straight through.

Also introduced a `randomEncryptionEnabled` derived boolean (`config.randomEncryption` when it's a bool, else `.enable or true`) since the rest of the module (`_create`/`_mount`/`_unmount`) branches on whether random encryption is active at all, and `!` doesn't work on an attrset.

I don't have a local Nix environment to run `nix flake check` / the test suite against this change, so flagging that so a maintainer/CI can verify directly.

Fixes #438