### PR TITLE
docs: point upgrade guide link at the local file, not a personal fork

### DIFF
--- a/docs/HowTo.md
+++ b/docs/HowTo.md
@@ -6,10 +6,7 @@ TODO: Still to be documented
 
 ## Upgrading From Older disko versions
 
-TODO: Include documentation here.
-
-For now, see the
-[upgrade guide](https://github.com/JillThornhill/disko/blob/master/docs/upgrade-guide.md)
+See the [upgrade guide](./upgrade-guide.md).
 
 ## Installing NixOS module
 


### PR DESCRIPTION
Closes #1245

## What

`docs/HowTo.md`'s "Upgrading From Older disko versions" section is a
`TODO: Include documentation here.` stub that links out to
`https://github.com/JillThornhill/disko/blob/master/docs/upgrade-guide.md`
— a personal fork, not this repo.

Turns out the docs already exist locally: `docs/upgrade-guide.md` in this
repo has 173 lines, more complete than the fork's 108-line copy (the fork's
version stops at 2023-04-07; this repo's already goes up to 2023-07-09). It
just wasn't linked from `HowTo.md`. I almost copied the fork's older content
over the local file before noticing the local one was already newer and
more complete — so this PR only fixes the link, it doesn't touch
`upgrade-guide.md`'s content at all.

## Testing

Documentation-only, single-line link fix. Confirmed `docs/upgrade-guide.md`
exists and renders as a normal repo-relative markdown link (matching the
convention already used elsewhere in `docs/`, e.g. `docs/INDEX.md`'s
`[How to Guide](./HowTo.md)`).

Marking this AI-assisted: this PR was authored by an AI coding agent
(Claude).
