### PR TITLE
fix: update deprecated `stdenv.*` aliases

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -35,7 +35,7 @@ let
       cp -r install-cli.nix cli.nix default.nix disk-deactivate lib $out/share/disko
 
       scripts=(disko)
-      ${lib.optionalString (!stdenv.isDarwin) ''
+      ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
         scripts+=(disko-install)
       ''}
 
@@ -52,7 +52,7 @@ let
                 coreutils
                 xcp
               ]
-              ++ lib.optional (!stdenv.isDarwin) nixos-install-tools
+              ++ lib.optional (!stdenv.hostPlatform.isDarwin) nixos-install-tools
             )
           }
       done


### PR DESCRIPTION
akin to nix-community/home-manager#9806:

> Any remaining deprecated `stdenv.*` aliases should be updated treewide (if there are any other), and checks should be added to guard against any warnings (which also would include deprecated alises)