### PR TITLE
feat(btrfs,luks): better default checksum collision resistance with xxhash

### DIFF
--- a/example/luks-btrfs-raid.nix
+++ b/example/luks-btrfs-raid.nix
@@ -54,8 +54,12 @@
                 content = {
                   type = "btrfs";
                   extraArgs = [
-                    "-d raid1"
+                    "--data raid1"
                     "/dev/mapper/p1" # Use decrypted mapped device, same name as defined in disk1
+                    # on LUKS, the default crc32c becomes always probabilistic, so choose the
+                    # algorithm with smaller collision chance and almost identical performance
+                    "--checksum"
+                    "xxhash"
                   ];
                   subvolumes = {
                     "/root" = {

--- a/example/luks-btrfs-subvolumes.nix
+++ b/example/luks-btrfs-subvolumes.nix
@@ -31,7 +31,9 @@
                 additionalKeyFiles = [ "/tmp/additionalSecret.key" ];
                 content = {
                   type = "btrfs";
-                  extraArgs = [ "-f" ];
+                  # on LUKS, the default crc32c becomes always probabilistic, so choose the
+                  # algorithm with smaller collision chance and almost identical performance
+                  extraArgs = [ "--force" "--checksum" "xxhash" ];
                   subvolumes = {
                     "/root" = {
                       mountpoint = "/";


### PR DESCRIPTION
Choose xxHash, which will catch errors with a higher probability. A single encrypted bit flip causes a 128-bit flip on the decrypted side. This makes the CRC32C property of being certain to catch 100% of errors in 1/2/3-bit flip use cases disappear and become probabilistic `1-2⁻³²`. And since we're already in a non-deterministic zone, it's better to choose the algorithm that has stronger collision resistance.