### PR TITLE
install-cli: source nixos configurations from package outputs

### DIFF
--- a/install-cli.nix
+++ b/install-cli.nix
@@ -7,7 +7,11 @@
   rootMountPoint ? "/mnt",
 }:
 let
-  originalSystem = (builtins.getFlake "${flake}").nixosConfigurations."${flakeAttr}";
+  outputs = (builtins.getFlake "${flake}");
+  originalSystem =
+    outputs.packages.${builtins.currentSystem}.nixosConfigurations."${flakeAttr}"
+      or outputs.legacyPackages.${builtins.currentSystem}.nixosConfigurations."${flakeAttr}"
+        or outputs.nixosConfigurations."${flakeAttr}";
   lib = originalSystem.pkgs.lib;
 
   deviceName =


### PR DESCRIPTION
`disko-install` only searched for NixOS configurations within the `nixosConfigurations` flake output. Related tools like `nixos-install` and `nixos-rebuild` additionally search for NixOS configurations within the `packages` and `legacyPackages` flake outputs. This commit adds this behavior to `disko-install`.